### PR TITLE
enforce allow_doubling and allow_halving everywhere

### DIFF
--- a/src/nucleate.F90
+++ b/src/nucleate.F90
@@ -1,4 +1,4 @@
-! Copyright (C) 2010-2012 Matthew West
+! Copyright (C) 2010-2015 Matthew West
 ! Licensed under the GNU General Public License version 2 or (at your
 ! option) any later version. See the file COPYING for details.
 
@@ -29,7 +29,7 @@ contains
 
   !> Do nucleation of the type given by the first argument.
   subroutine nucleate(nucleate_type, nucleate_source, env_state, gas_data, &
-       aero_data, aero_state, gas_state, del_t)
+       aero_data, aero_state, gas_state, del_t, allow_doubling, allow_halving)
 
     !> Type of nucleation.
     integer, intent(in) :: nucleate_type
@@ -47,10 +47,15 @@ contains
     type(gas_state_t), intent(inout) :: gas_state
     !> Time to perform nucleation for.
     real(kind=dp), intent(in) :: del_t
+    !> Whether to allow doubling of the population.
+    logical, intent(in) :: allow_doubling
+    !> Whether to allow halving of the population.
+    logical, intent(in) :: allow_halving
 
     if (nucleate_type == NUCLEATE_TYPE_SULF_ACID) then
        call nucleate_sulf_acid(nucleate_source, env_state, gas_data, &
-            aero_data, aero_state, gas_state, del_t)
+            aero_data, aero_state, gas_state, del_t, allow_doubling, &
+            allow_halving)
     else
        call die_msg(983831728, &
             "unknown nucleation type: " &
@@ -76,7 +81,7 @@ contains
   !! <i>J. Geophys. Res.</i>, 113, D10209, doi:<a
   !! href="http://dx.doi.org/10.1029/2007JD009253">10.1029/2007JD009253</a>.
   subroutine nucleate_sulf_acid(nucleate_source, env_state, gas_data, &
-       aero_data, aero_state, gas_state, del_t)
+       aero_data, aero_state, gas_state, del_t, allow_doubling, allow_halving)
 
     !> Nucleate source number.
     integer, intent(in) :: nucleate_source
@@ -92,6 +97,10 @@ contains
     type(gas_state_t), intent(inout) :: gas_state
     !> Time to perform nucleation for.
     real(kind=dp), intent(in) :: del_t
+    !> Whether to allow doubling of the population.
+    logical, intent(in) :: allow_doubling
+    !> Whether to allow halving of the population.
+    logical, intent(in) :: allow_halving
 
     real(kind=dp), parameter :: nucleate_coeff = 1d-18 ! K (m^3 s^{-1})
     real(kind=dp), parameter :: nucleate_diam = 1d-9   ! diameter of new
@@ -128,7 +137,7 @@ contains
        n_samp_avg = nucleate_rate * del_t / aero_weight_num_conc_at_radius( &
             aero_state%awa%weight(i_group, i_class), diam2rad(nucleate_diam))
        call aero_state_prepare_weight_for_add(aero_state, i_group, i_class, &
-            n_samp_avg)
+            n_samp_avg, allow_doubling, allow_halving)
 
        ! determine number of nucleated particles
        n_samp_avg = nucleate_rate * del_t / aero_weight_num_conc_at_radius( &

--- a/src/partmc.F90
+++ b/src/partmc.F90
@@ -629,7 +629,8 @@ contains
           end if
           call aero_state_set_n_part_ideal(aero_state, n_part)
           call aero_state_add_aero_dist_sample(aero_state, aero_data, &
-               aero_dist_init, 1d0, 0d0)
+               aero_dist_init, 1d0, 0d0, run_part_opt%allow_doubling, &
+               run_part_opt%allow_halving)
        end if
        call env_state_copy(env_state_init, env_state)
        call scenario_init_env_state(scenario, env_state, &

--- a/src/run_part.F90
+++ b/src/run_part.F90
@@ -216,7 +216,8 @@ contains
           n_part_before = aero_state_total_particles(aero_state)
           call nucleate(run_part_opt%nucleate_type, &
                run_part_opt%nucleate_source, env_state, gas_data, aero_data, &
-               aero_state, gas_state, run_part_opt%del_t)
+               aero_state, gas_state, run_part_opt%del_t, &
+               run_part_opt%allow_doubling, run_part_opt%allow_halving)
           n_nuc = aero_state_total_particles(aero_state) &
                - n_part_before
           progress_n_nuc = progress_n_nuc + n_nuc
@@ -255,7 +256,8 @@ contains
             env_state, old_env_state, gas_data, gas_state)
        call scenario_update_aero_state(scenario, run_part_opt%del_t, &
             env_state, old_env_state, aero_data, aero_state, n_emit, &
-            n_dil_in, n_dil_out)
+            n_dil_in, n_dil_out, run_part_opt%allow_doubling, &
+            run_part_opt%allow_halving)
        progress_n_emit = progress_n_emit + n_emit
        progress_n_dil_in = progress_n_dil_in + n_dil_in
        progress_n_dil_out = progress_n_dil_out + n_dil_out

--- a/src/scenario.F90
+++ b/src/scenario.F90
@@ -1,4 +1,4 @@
-! Copyright (C) 2005-2012 Nicole Riemer and Matthew West
+! Copyright (C) 2005-2015 Nicole Riemer and Matthew West
 ! Licensed under the GNU General Public License version 2 or (at your
 ! option) any later version. See the file COPYING for details.
 
@@ -426,7 +426,8 @@ contains
   !! model. We additionally scale the number concentration to account
   !! for temperature changes.
   subroutine scenario_update_aero_state(scenario, delta_t, env_state, &
-       old_env_state, aero_data, aero_state, n_emit, n_dil_in, n_dil_out)
+       old_env_state, aero_data, aero_state, n_emit, n_dil_in, n_dil_out, &
+       allow_doubling, allow_halving)
 
     !> Scenario.
     type(scenario_t), intent(in) :: scenario
@@ -446,6 +447,10 @@ contains
     integer, intent(out) :: n_dil_in
     !> Number of diluted-out particles.
     integer, intent(out) :: n_dil_out
+    !> Whether to allow doubling of the population.
+    logical, intent(in) :: allow_doubling
+    !> Whether to allow halving of the population.
+    logical, intent(in) :: allow_halving
 
     real(kind=dp) :: emission_rate_scale, dilution_rate, p
     type(aero_dist_t) :: emissions, background
@@ -458,7 +463,8 @@ contains
          env_state%elapsed_time, emissions, emission_rate_scale)
     p = emission_rate_scale * delta_t / env_state%height
     call aero_state_add_aero_dist_sample(aero_state, aero_data, &
-         emissions, p, env_state%elapsed_time, n_emit)
+         emissions, p, env_state%elapsed_time, allow_doubling, allow_halving, &
+         n_emit)
     call aero_dist_deallocate(emissions)
 
     ! dilution
@@ -478,7 +484,8 @@ contains
     call aero_state_deallocate(aero_state_delta)
     ! addition from background
     call aero_state_add_aero_dist_sample(aero_state, aero_data, &
-         background, 1d0 - p, env_state%elapsed_time, n_dil_in)
+         background, 1d0 - p, env_state%elapsed_time, allow_doubling, &
+         allow_halving, n_dil_in)
     call aero_dist_deallocate(background)
 
     ! update computational volume


### PR DESCRIPTION
This fixes #8 by enforcing the `allow_doubling` and `allow_halving` flags everywhere in the code. The changes were in initial condition sampling, in scenario (emissions, dilution, etc), and in nucleation.

I'm not sure how useful this really is, especially with `NUMMASS_SOURCE` weighting, because the number of particles can be hard to control.

I tested this on `test/emission` and `test/brownian`.

@jcurtis2, can you take a look at this and let me know what you think? Does this address #8 like you wanted?
