### PR TITLE
improve text baseline in mpl_helper

### DIFF
--- a/tool/mpl_helper.py
+++ b/tool/mpl_helper.py
@@ -9,6 +9,7 @@ matplotlib.use('PDF')
 import matplotlib.pyplot as plt
 
 matplotlib.rc('text', usetex = True)
+matplotlib.rc('text.latex', preview = True)
 matplotlib.rc('xtick.major', pad = 8)
 matplotlib.rc('ytick.major', pad = 8)
 matplotlib.rc('xtick', labelsize = 10)


### PR DESCRIPTION
Added preview=True option to help with the baseline of text which was incorrect when there were labels with subscripts such as chemical symbols or a variables with subscripts. This does require that the preview package is present.

[http://stackoverflow.com/questions/40424249/vertical-alignment-of-matplotlib-legend-labels-with-latex-math](url)
[http://matplotlib.org/2.0.0/examples/pylab_examples/usetex_baseline_test.html](url)