### PR TITLE
added retries to tests

### DIFF
--- a/test/additive/test_additive_2.sh
+++ b/test/additive/test_additive_2.sh
@@ -7,7 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-8 --dmax 1e-3 --nbin 160 out/additive_part_0001
-../../extract_sectional_aero_size --mass out/additive_exact
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.2 out/additive_exact_aero_size_mass.txt out/additive_part_0001_aero_size_mass.txt
+if ! ../../extract_aero_size --mass --dmin 1e-8 --dmax 1e-3 --nbin 160 out/additive_part_0001 || \
+   ! ../../extract_sectional_aero_size --mass out/additive_exact || \
+   ! ../../numeric_diff --by col --rel-tol 0.2 out/additive_exact_aero_size_mass.txt out/additive_part_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../partmc run_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_01.sh
+++ b/test/average/test_average_01.sh
@@ -9,9 +9,27 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_part.spec
-../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_0001
-../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_comp_0001
-../../numeric_diff --by col --rel-tol 1e-12 out/average_0001_aero_size_num.txt out/average_comp_0001_aero_size_num.txt
+if ! ../../partmc run_part.spec || \
+   ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp || \
+
+   ! ../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_0001 || \
+   ! ../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_comp_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 1e-12 out/average_0001_aero_size_num.txt out/average_comp_0001_aero_size_num.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_02.sh
+++ b/test/average/test_average_02.sh
@@ -7,6 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_0001
-../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_comp_0001
-../../numeric_diff --by col --rel-tol 1e-12 out/average_0001_aero_size_mass.txt out/average_comp_0001_aero_size_mass.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_0001 || \
+   ! ../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_comp_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 1e-12 out/average_0001_aero_size_mass.txt out/average_comp_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_03.sh
+++ b/test/average/test_average_03.sh
@@ -7,6 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_time out/average_0001
-../../extract_aero_time out/average_comp_0001
-../../numeric_diff --rel-tol 1e-12 out/average_0001_aero_time.txt out/average_comp_0001_aero_time.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_time out/average_0001 || \
+   ! ../../extract_aero_time out/average_comp_0001 || \
+   ! ../../numeric_diff --rel-tol 1e-12 out/average_0001_aero_time.txt out/average_comp_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_04.sh
+++ b/test/average/test_average_04.sh
@@ -7,8 +7,28 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_particles out/average_0001_00000001.nc
-sort out/average_0001_00000001_aero_particles.txt > out/average_aero_particles_sorted.txt
-../../extract_aero_particles out/average_comp_0001_00000001.nc
-sort out/average_comp_0001_00000001_aero_particles.txt > out/average_comp_aero_particles_sorted.txt
-../../numeric_diff --by elem --min-col 3 --max-col 4 --rel-tol 3 out/average_aero_particles_sorted.txt out/average_comp_aero_particles_sorted.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_particles out/average_0001_00000001.nc || \
+   ! sort out/average_0001_00000001_aero_particles.txt > out/average_aero_particles_sorted.txt || \
+   ! ../../extract_aero_particles out/average_comp_0001_00000001.nc || \
+   ! sort out/average_comp_0001_00000001_aero_particles.txt > out/average_comp_aero_particles_sorted.txt || \
+   ! ../../numeric_diff --by elem --min-col 3 --max-col 4 --rel-tol 3 out/average_aero_particles_sorted.txt out/average_comp_aero_particles_sorted.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_05.sh
+++ b/test/average/test_average_05.sh
@@ -7,7 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../bin_average_size 1e-10 1e-4 24 wet average number out/average_0001_00000001.nc out/average_sizenum
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_sizenum_0001
-../../numeric_diff --by col --rel-tol 1e-12 out/average_0001_aero_size_num.txt out/average_sizenum_0001_aero_size_num.txt
+if ! ../../bin_average_size 1e-10 1e-4 24 wet average number out/average_0001_00000001.nc out/average_sizenum || \
+   ! ../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_sizenum_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 1e-12 out/average_0001_aero_size_num.txt out/average_sizenum_0001_aero_size_num.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_06.sh
+++ b/test/average/test_average_06.sh
@@ -7,5 +7,25 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_sizenum_0001
-../../numeric_diff --by col --rel-tol 0.01 out/average_0001_aero_size_mass.txt out/average_sizenum_0001_aero_size_mass.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_sizenum_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 0.01 out/average_0001_aero_size_mass.txt out/average_sizenum_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_07.sh
+++ b/test/average/test_average_07.sh
@@ -7,5 +7,25 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_time out/average_sizenum_0001
-../../numeric_diff --rel-tol 1e-10 out/average_0001_aero_time.txt out/average_sizenum_0001_aero_time.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_time out/average_sizenum_0001 || \
+   ! ../../numeric_diff --rel-tol 1e-10 out/average_0001_aero_time.txt out/average_sizenum_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_08.sh
+++ b/test/average/test_average_08.sh
@@ -7,6 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_particles out/average_sizenum_0001_00000001.nc
-sort out/average_sizenum_0001_00000001_aero_particles.txt > out/average_sizenum_aero_particles_sorted.txt
-../../numeric_diff --by elem --min-col 3 --max-col 4 --rel-tol 3 out/average_aero_particles_sorted.txt out/average_sizenum_aero_particles_sorted.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_particles out/average_sizenum_0001_00000001.nc || \
+   ! sort out/average_sizenum_0001_00000001_aero_particles.txt > out/average_sizenum_aero_particles_sorted.txt || \
+   ! ../../numeric_diff --by elem --min-col 3 --max-col 4 --rel-tol 3 out/average_aero_particles_sorted.txt out/average_sizenum_aero_particles_sorted.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_09.sh
+++ b/test/average/test_average_09.sh
@@ -7,7 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../bin_average_size 1e-10 1e-4 24 wet average volume out/average_0001_00000001.nc out/average_sizevol
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_sizevol_0001
-../../numeric_diff --by col --rel-tol 0.2 out/average_0001_aero_size_num.txt out/average_sizevol_0001_aero_size_num.txt
+if ! ../../bin_average_size 1e-10 1e-4 24 wet average volume out/average_0001_00000001.nc out/average_sizevol || \
+   ! ../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_sizevol_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 0.2 out/average_0001_aero_size_num.txt out/average_sizevol_0001_aero_size_num.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_10.sh
+++ b/test/average/test_average_10.sh
@@ -7,5 +7,25 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_sizevol_0001
-../../numeric_diff --by col --rel-tol 0.1 out/average_0001_aero_size_mass.txt out/average_sizevol_0001_aero_size_mass.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_sizevol_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 0.1 out/average_0001_aero_size_mass.txt out/average_sizevol_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_11.sh
+++ b/test/average/test_average_11.sh
@@ -7,5 +7,25 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_time out/average_sizevol_0001
-../../numeric_diff --rel-tol 1e-10 out/average_0001_aero_time.txt out/average_sizevol_0001_aero_time.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_time out/average_sizevol_0001 || \
+   ! ../../numeric_diff --rel-tol 1e-10 out/average_0001_aero_time.txt out/average_sizevol_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_12.sh
+++ b/test/average/test_average_12.sh
@@ -7,6 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_particles out/average_sizevol_0001_00000001.nc
-sort out/average_sizevol_0001_00000001_aero_particles.txt > out/average_sizevol_aero_particles_sorted.txt
-../../numeric_diff --by elem --min-col 3 --max-col 4 --rel-tol 3 out/average_aero_particles_sorted.txt out/average_sizevol_aero_particles_sorted.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_particles out/average_sizevol_0001_00000001.nc || \
+   ! sort out/average_sizevol_0001_00000001_aero_particles.txt > out/average_sizevol_aero_particles_sorted.txt || \
+   ! ../../numeric_diff --by elem --min-col 3 --max-col 4 --rel-tol 3 out/average_aero_particles_sorted.txt out/average_sizevol_aero_particles_sorted.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_13.sh
+++ b/test/average/test_average_13.sh
@@ -7,7 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../bin_average_size 1e-10 1e-4 24 wet average number out/average_comp_0001_00000001.nc out/average_compsizenum
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_compsizenum_0001
-../../numeric_diff --by col --rel-tol 1e-12 out/average_0001_aero_size_num.txt out/average_compsizenum_0001_aero_size_num.txt
+if ! ../../bin_average_size 1e-10 1e-4 24 wet average number out/average_comp_0001_00000001.nc out/average_compsizenum || \
+   ! ../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_compsizenum_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 1e-12 out/average_0001_aero_size_num.txt out/average_compsizenum_0001_aero_size_num.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_14.sh
+++ b/test/average/test_average_14.sh
@@ -7,5 +7,25 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_compsizenum_0001
-../../numeric_diff --by col --rel-tol 1e-12 out/average_0001_aero_size_mass.txt out/average_compsizenum_0001_aero_size_mass.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_compsizenum_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 1e-12 out/average_0001_aero_size_mass.txt out/average_compsizenum_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_15.sh
+++ b/test/average/test_average_15.sh
@@ -7,5 +7,25 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_time out/average_compsizenum_0001
-../../numeric_diff --rel-tol 1e-10 out/average_0001_aero_time.txt out/average_compsizenum_0001_aero_time.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_time out/average_compsizenum_0001 || \
+   ! ../../numeric_diff --rel-tol 1e-10 out/average_0001_aero_time.txt out/average_compsizenum_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_16.sh
+++ b/test/average/test_average_16.sh
@@ -7,6 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_particles out/average_compsizenum_0001_00000001.nc
-sort out/average_compsizenum_0001_00000001_aero_particles.txt > out/average_compsizenum_aero_particles_sorted.txt
-../../numeric_diff --by elem --min-col 3 --max-col 4 --rel-tol 3 out/average_aero_particles_sorted.txt out/average_compsizenum_aero_particles_sorted.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_particles out/average_compsizenum_0001_00000001.nc || \
+   ! sort out/average_compsizenum_0001_00000001_aero_particles.txt > out/average_compsizenum_aero_particles_sorted.txt || \
+   ! ../../numeric_diff --by elem --min-col 3 --max-col 4 --rel-tol 3 out/average_aero_particles_sorted.txt out/average_compsizenum_aero_particles_sorted.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_17.sh
+++ b/test/average/test_average_17.sh
@@ -7,7 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../bin_average_size 1e-10 1e-4 24 wet average volume out/average_comp_0001_00000001.nc out/average_compsizevol
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_compsizevol_0001
-../../numeric_diff --by col --rel-tol 0.1 out/average_0001_aero_size_num.txt out/average_compsizevol_0001_aero_size_num.txt
+if ! ../../bin_average_size 1e-10 1e-4 24 wet average volume out/average_comp_0001_00000001.nc out/average_compsizevol || \
+   ! ../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_compsizevol_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 0.1 out/average_0001_aero_size_num.txt out/average_compsizevol_0001_aero_size_num.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_18.sh
+++ b/test/average/test_average_18.sh
@@ -7,5 +7,25 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_compsizevol_0001
-../../numeric_diff --by col --rel-tol 1e-12 out/average_0001_aero_size_mass.txt out/average_compsizevol_0001_aero_size_mass.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 24 out/average_compsizevol_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 1e-12 out/average_0001_aero_size_mass.txt out/average_compsizevol_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_19.sh
+++ b/test/average/test_average_19.sh
@@ -7,5 +7,25 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_time out/average_compsizevol_0001
-../../numeric_diff --rel-tol 1e-10 out/average_0001_aero_time.txt out/average_compsizevol_0001_aero_time.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_time out/average_compsizevol_0001 || \
+   ! ../../numeric_diff --rel-tol 1e-10 out/average_0001_aero_time.txt out/average_compsizevol_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/average/test_average_20.sh
+++ b/test/average/test_average_20.sh
@@ -7,6 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_particles out/average_compsizevol_0001_00000001.nc
-sort out/average_compsizevol_0001_00000001_aero_particles.txt > out/average_compsizevol_aero_particles_sorted.txt
-../../numeric_diff --by elem --min-col 3 --max-col 4 --rel-tol 3 out/average_aero_particles_sorted.txt out/average_compsizevol_aero_particles_sorted.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_particles out/average_compsizevol_0001_00000001.nc || \
+   ! sort out/average_compsizevol_0001_00000001_aero_particles.txt > out/average_compsizevol_aero_particles_sorted.txt || \
+   ! ../../numeric_diff --by elem --min-col 3 --max-col 4 --rel-tol 3 out/average_aero_particles_sorted.txt out/average_compsizevol_aero_particles_sorted.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../bin_average_comp 1e-10 1e-4 24 wet out/average_0001_00000001.nc out/average_comp; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/bidisperse/test_bidisperse_1.sh
+++ b/test/bidisperse/test_bidisperse_1.sh
@@ -9,12 +9,27 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_part.spec
-../../test_bidisperse_extract
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../test_bidisperse_ode
-
+if ! ../../partmc run_part.spec || \
+   ! ../../test_bidisperse_extract || \
+   ! ../../test_bidisperse_ode || \
 # extract size distributions for plotting
-../../extract_aero_size --num --dmin 1e-5 --dmax 1e-3 --nbin 255 out/bidisperse_part_0001
-
-../../numeric_diff --by col --rel-tol 0.3 out/bidisperse_ode_data.txt out/bidisperse_part_data.txt
+   ! ../../extract_aero_size --num --dmin 1e-5 --dmax 1e-3 --nbin 255 out/bidisperse_part_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 0.3 out/bidisperse_ode_data.txt out/bidisperse_part_data.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/brownian/test_brownian_1.sh
+++ b/test/brownian/test_brownian_1.sh
@@ -9,9 +9,26 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_part.spec
-../../partmc run_sect.spec
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 220 out/brownian_part_0001
-../../extract_sectional_aero_size --num out/brownian_sect
-../../numeric_diff --by col --rel-tol 0.4 out/brownian_sect_aero_size_num.txt out/brownian_part_0001_aero_size_num.txt
+if ! ../../partmc run_part.spec || \
+   ! ../../partmc run_sect.spec || \
+   ! ../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 220 out/brownian_part_0001 || \
+   ! ../../extract_sectional_aero_size --num out/brownian_sect || \
+   ! ../../numeric_diff --by col --rel-tol 0.4 out/brownian_sect_aero_size_num.txt out/brownian_part_0001_aero_size_num.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/brownian/test_brownian_2.sh
+++ b/test/brownian/test_brownian_2.sh
@@ -7,6 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 220 out/brownian_part_0001
-../../extract_sectional_aero_size --mass out/brownian_sect
-../../numeric_diff --by col --rel-tol 0.4 out/brownian_sect_aero_size_mass.txt out/brownian_part_0001_aero_size_mass.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 220 out/brownian_part_0001 || \
+   ! ../../extract_sectional_aero_size --mass out/brownian_sect || \
+   ! ../../numeric_diff --by col --rel-tol 0.4 out/brownian_sect_aero_size_mass.txt out/brownian_part_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../partmc run_sect.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/brownian/test_brownian_3.sh
+++ b/test/brownian/test_brownian_3.sh
@@ -7,9 +7,29 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
 for f in out/brownian_part_????_00000001.nc ; do
     ../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 220 ${f/_00000001.nc/}
 done
-../../numeric_average out/brownian_part_aero_size_num_average.txt out/brownian_part_????_aero_size_num.txt
-../../extract_sectional_aero_size --num out/brownian_sect
-../../numeric_diff --by col --rel-tol 0.2 out/brownian_sect_aero_size_num.txt out/brownian_part_aero_size_num_average.txt
+if ! ../../numeric_average out/brownian_part_aero_size_num_average.txt out/brownian_part_????_aero_size_num.txt || \
+   ! ../../extract_sectional_aero_size --num out/brownian_sect || \
+   ! ../../numeric_diff --by col --rel-tol 0.2 out/brownian_sect_aero_size_num.txt out/brownian_part_aero_size_num_average.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../partmc run_sect.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/brownian/test_brownian_4.sh
+++ b/test/brownian/test_brownian_4.sh
@@ -7,9 +7,29 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
 for f in out/brownian_part_????_00000001.nc ; do
     ../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 220 ${f/_00000001.nc/}
 done
-../../numeric_average out/brownian_part_aero_size_mass_average.txt out/brownian_part_????_aero_size_mass.txt
-../../extract_sectional_aero_size --mass out/brownian_sect
-../../numeric_diff --by col --rel-tol 0.3 out/brownian_sect_aero_size_mass.txt out/brownian_part_aero_size_mass_average.txt
+if ! ../../numeric_average out/brownian_part_aero_size_mass_average.txt out/brownian_part_????_aero_size_mass.txt || \
+   ! ../../extract_sectional_aero_size --mass out/brownian_sect || \
+   ! ../../numeric_diff --by col --rel-tol 0.3 out/brownian_sect_aero_size_mass.txt out/brownian_part_aero_size_mass_average.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../partmc run_sect.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/condense/test_condense_1.sh
+++ b/test/condense/test_condense_1.sh
@@ -9,7 +9,24 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_part.spec
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_env out/condense_0001
-../../numeric_diff --by col --rel-tol 1e-4 ref_condense_0001_env.txt out/condense_0001_env.txt
+if ! ../../partmc run_part.spec || \
+   ! ../../extract_env out/condense_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 1e-4 ref_condense_0001_env.txt out/condense_0001_env.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/condense/test_condense_2.sh
+++ b/test/condense/test_condense_2.sh
@@ -7,6 +7,24 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_time out/condense_0001
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --min-col 23 --max-col 23 --rel-tol 0.05 ref_condense_0001_aero_time.txt out/condense_0001_aero_time.txt
+if ! ../../extract_aero_time out/condense_0001 || \
+   ! ../../numeric_diff --min-col 23 --max-col 23 --rel-tol 0.05 ref_condense_0001_aero_time.txt out/condense_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+          if ! ../../partmc run_part.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/emission/test_emission_1.sh
+++ b/test/emission/test_emission_1.sh
@@ -9,10 +9,26 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_part.spec
-../../partmc run_exact.spec
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_size --num --dmin 1e-8 --dmax 1e-3 --nbin 160 out/emission_part_0001
-../../extract_sectional_aero_size --num out/emission_exact
-
-../../numeric_diff --by col --rel-tol 0.05 out/emission_exact_aero_size_num.txt out/emission_part_0001_aero_size_num.txt
+if ! ../../partmc run_part.spec || \
+   ! ../../partmc run_exact.spec || \
+   ! ../../extract_aero_size --num --dmin 1e-8 --dmax 1e-3 --nbin 160 out/emission_part_0001 || \
+   ! ../../extract_sectional_aero_size --num out/emission_exact || \
+   ! ../../numeric_diff --by col --rel-tol 0.05 out/emission_exact_aero_size_num.txt out/emission_part_0001_aero_size_num.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/emission/test_emission_2.sh
+++ b/test/emission/test_emission_2.sh
@@ -7,7 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-8 --dmax 1e-3 --nbin 160 out/emission_part_0001
-../../extract_sectional_aero_size --mass out/emission_exact
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.1 out/emission_exact_aero_size_mass.txt out/emission_part_0001_aero_size_mass.txt
+if ! ../../extract_aero_size --mass --dmin 1e-8 --dmax 1e-3 --nbin 160 out/emission_part_0001 || \
+   ! ../../extract_sectional_aero_size --mass out/emission_exact || \
+   ! ../../numeric_diff --by col --rel-tol 0.1 out/emission_exact_aero_size_mass.txt out/emission_part_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../partmc run_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/emission/test_emission_3.sh
+++ b/test/emission/test_emission_3.sh
@@ -7,7 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_time out/emission_part_0001
-../../extract_sectional_aero_time out/emission_exact
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.1 out/emission_exact_aero_time.txt out/emission_part_0001_aero_time.txt
+if ! ../../extract_aero_time out/emission_part_0001 || \
+   ! ../../extract_sectional_aero_time out/emission_exact || \
+   ! ../../numeric_diff --by col --rel-tol 0.1 out/emission_exact_aero_time.txt out/emission_part_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../partmc run_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/fractal/test_fractal_1.sh
+++ b/test/fractal/test_fractal_1.sh
@@ -7,4 +7,22 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../test_fractal_radii_conversion
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../test_fractal_radii_conversion; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/fractal/test_fractal_2.sh
+++ b/test/fractal/test_fractal_2.sh
@@ -9,12 +9,40 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_part_brown_free_df_2_4_upto1000s.spec
-../../partmc run_part_brown_free_df_2_4_restart.spec
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../test_fractal_dimless_time --free out/part_brown_free_df_2_4_0001
-../../test_fractal_dimless_time --free out/restart_part_brown_free_df_2_4_0001
+if ! ../../partmc run_part_brown_free_df_2_4_upto1000s.spec || \
+   ! ../../partmc run_part_brown_free_df_2_4_restart.spec || \
+   ! ../../test_fractal_dimless_time --free out/part_brown_free_df_2_4_0001 || \
+   ! ../../test_fractal_dimless_time --free out/restart_part_brown_free_df_2_4_0001; then
+	echo Failure "$counter"
+	if [ "$counter" -gt 10 ]
+	then
+		echo FAIL
+		exit 1
+	fi
+	echo retrying...
+	((counter++))
+	continue
+fi
+
 tail -n +2 out/restart_part_brown_free_df_2_4_0001_dimless_time.txt > out/restart_part_brown_free_df_2_4_0001_dimless_time_tailed.txt
 cat out/part_brown_free_df_2_4_0001_dimless_time.txt out/restart_part_brown_free_df_2_4_0001_dimless_time_tailed.txt > out/part_brown_free_df_2_4_0001_dimless_t_series.txt
 
-../../numeric_diff --by col --rel-tol 0.1 ref_free_df_2_4_dimless_time_regrid.txt out/part_brown_free_df_2_4_0001_dimless_t_series.txt
+if ! ../../numeric_diff --by col --rel-tol 0.1 ref_free_df_2_4_dimless_time_regrid.txt out/part_brown_free_df_2_4_0001_dimless_t_series.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/fractal/test_fractal_3.sh
+++ b/test/fractal/test_fractal_3.sh
@@ -9,12 +9,40 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_part_brown_cont_df_1_8_upto1000s.spec
-../../partmc run_part_brown_cont_df_1_8_restart.spec
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../test_fractal_dimless_time --cont out/part_brown_cont_df_1_8_0001
-../../test_fractal_dimless_time --cont out/restart_part_brown_cont_df_1_8_0001
+if ! ../../partmc run_part_brown_cont_df_1_8_upto1000s.spec || \
+   ! ../../partmc run_part_brown_cont_df_1_8_restart.spec || \
+   ! ../../test_fractal_dimless_time --cont out/part_brown_cont_df_1_8_0001 || \
+   ! ../../test_fractal_dimless_time --cont out/restart_part_brown_cont_df_1_8_0001; then
+	echo Failure "$counter"
+	if [ "$counter" -gt 10 ]
+	then
+		echo FAIL
+		exit 1
+	fi
+	echo retrying...
+	((counter++))
+	continue
+fi
+
 tail -n +2 out/restart_part_brown_cont_df_1_8_0001_dimless_time.txt > out/restart_part_brown_cont_df_1_8_0001_dimless_time_tailed.txt
 cat out/part_brown_cont_df_1_8_0001_dimless_time.txt out/restart_part_brown_cont_df_1_8_0001_dimless_time_tailed.txt > out/part_brown_cont_df_1_8_0001_dimless_t_series.txt
 
-../../numeric_diff --by col --rel-tol 0.1 ref_cont_df_1_8_dimless_time_regrid.txt out/part_brown_cont_df_1_8_0001_dimless_t_series.txt
+if ! ../../numeric_diff --by col --rel-tol 0.1 ref_cont_df_1_8_dimless_time_regrid.txt out/part_brown_cont_df_1_8_0001_dimless_t_series.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/loss/test_loss_01.sh
+++ b/test/loss/test_loss_01.sh
@@ -9,10 +9,26 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_constant_part.spec
-../../partmc run_constant_exact.spec
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_time out/loss_part_constant_0001
-../../extract_sectional_aero_time out/loss_exact_constant
-
-../../numeric_diff --by col --rel-tol 0.05 out/loss_exact_constant_aero_time.txt out/loss_part_constant_0001_aero_time.txt
+if ! ../../partmc run_constant_part.spec || \
+   ! ../../partmc run_constant_exact.spec || \
+   ! ../../extract_aero_time out/loss_part_constant_0001 || \
+   ! ../../extract_sectional_aero_time out/loss_exact_constant || \
+   ! ../../numeric_diff --by col --rel-tol 0.05 out/loss_exact_constant_aero_time.txt out/loss_part_constant_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/loss/test_loss_02.sh
+++ b/test/loss/test_loss_02.sh
@@ -9,7 +9,27 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../extract_aero_size --num --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_constant_0001
-../../extract_sectional_aero_size --num out/loss_exact_constant
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.3 out/loss_exact_constant_aero_size_num.txt out/loss_part_constant_0001_aero_size_num.txt
+if ! ../../extract_aero_size --num --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_constant_0001 || \
+   ! ../../extract_sectional_aero_size --num out/loss_exact_constant || \
+   ! ../../numeric_diff --by col --rel-tol 0.3 out/loss_exact_constant_aero_size_num.txt out/loss_part_constant_0001_aero_size_num.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_constant_part.spec; then continue; fi
+	  if ! ../../partmc run_constant_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done
+

--- a/test/loss/test_loss_03.sh
+++ b/test/loss/test_loss_03.sh
@@ -7,7 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_constant_0001
-../../extract_sectional_aero_size --mass out/loss_exact_constant
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.3 out/loss_exact_constant_aero_size_mass.txt out/loss_part_constant_0001_aero_size_mass.txt
+if ! ../../extract_aero_size --mass --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_constant_0001 || \
+   ! ../../extract_sectional_aero_size --mass out/loss_exact_constant || \
+   ! ../../numeric_diff --by col --rel-tol 0.3 out/loss_exact_constant_aero_size_mass.txt out/loss_part_constant_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_constant_part.spec; then continue; fi
+	  if ! ../../partmc run_constant_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/loss/test_loss_04.sh
+++ b/test/loss/test_loss_04.sh
@@ -9,10 +9,30 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_volume_part.spec
-../../partmc run_volume_exact.spec
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_time out/loss_part_volume_0001
-../../extract_sectional_aero_time out/loss_exact_volume
-
-../../numeric_diff --by col --rel-tol 0.1 out/loss_exact_volume_aero_time.txt out/loss_part_volume_0001_aero_time.txt
+if ! ../../partmc run_volume_part.spec || \
+   ! ../../partmc run_volume_exact.spec || \
+   ! ../../extract_aero_time out/loss_part_volume_0001 || \
+   ! ../../extract_sectional_aero_time out/loss_exact_volume || \
+   ! ../../numeric_diff --by col --rel-tol 0.1 out/loss_exact_volume_aero_time.txt out/loss_part_volume_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_constant_part.spec; then continue; fi
+	  if ! ../../partmc run_constant_exact.spec; then continue; fi
+          if ! ../../partmc run_volume_part.spec; then continue; fi
+          if ! ../../partmc run_volume_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/loss/test_loss_05.sh
+++ b/test/loss/test_loss_05.sh
@@ -9,7 +9,26 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../extract_aero_size --num --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_volume_0001
-../../extract_sectional_aero_size --num out/loss_exact_volume
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.3 out/loss_exact_volume_aero_size_num.txt out/loss_part_volume_0001_aero_size_num.txt
+if ! ../../extract_aero_size --num --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_volume_0001 || \
+   ! ../../extract_sectional_aero_size --num out/loss_exact_volume || \
+   ! ../../numeric_diff --by col --rel-tol 0.3 out/loss_exact_volume_aero_size_num.txt out/loss_part_volume_0001_aero_size_num.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_constant_part.spec; then continue; fi
+	  if ! ../../partmc run_constant_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/loss/test_loss_06.sh
+++ b/test/loss/test_loss_06.sh
@@ -7,7 +7,28 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_volume_0001
-../../extract_sectional_aero_size --mass out/loss_exact_volume
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.3 out/loss_exact_volume_aero_size_mass.txt out/loss_part_volume_0001_aero_size_mass.txt
+if ! ../../extract_aero_size --mass --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_volume_0001 || \
+   ! ../../extract_sectional_aero_size --mass out/loss_exact_volume || \
+   ! ../../numeric_diff --by col --rel-tol 0.3 out/loss_exact_volume_aero_size_mass.txt out/loss_part_volume_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_constant_part.spec; then continue; fi
+	  if ! ../../partmc run_constant_exact.spec; then continue; fi
+          if ! ../../partmc run_volume_part.spec; then continue; fi
+          if ! ../../partmc run_volume_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/loss/test_loss_07.sh
+++ b/test/loss/test_loss_07.sh
@@ -9,10 +9,30 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_drydep_part.spec
-../../partmc run_drydep_exact.spec
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_time out/loss_part_drydep_0001
-../../extract_sectional_aero_time out/loss_exact_drydep
-
-../../numeric_diff --by col --rel-tol 0.15 out/loss_exact_drydep_aero_time.txt out/loss_part_drydep_0001_aero_time.txt
+if ! ../../partmc run_drydep_part.spec || \
+   ! ../../partmc run_drydep_exact.spec || \
+   ! ../../extract_aero_time out/loss_part_drydep_0001 || \
+   ! ../../extract_sectional_aero_time out/loss_exact_drydep || \
+   ! ../../numeric_diff --by col --rel-tol 0.15 out/loss_exact_drydep_aero_time.txt out/loss_part_drydep_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_constant_part.spec; then continue; fi
+	  if ! ../../partmc run_constant_exact.spec; then continue; fi
+          if ! ../../partmc run_volume_part.spec; then continue; fi
+          if ! ../../partmc run_volume_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/loss/test_loss_08.sh
+++ b/test/loss/test_loss_08.sh
@@ -9,7 +9,30 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../extract_aero_size --num --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_drydep_0001
-../../extract_sectional_aero_size --num out/loss_exact_drydep
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.15 out/loss_exact_drydep_aero_size_num.txt out/loss_part_drydep_0001_aero_size_num.txt
+if ! ../../extract_aero_size --num --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_drydep_0001 || \
+   ! ../../extract_sectional_aero_size --num out/loss_exact_drydep || \
+   ! ../../numeric_diff --by col --rel-tol 0.15 out/loss_exact_drydep_aero_size_num.txt out/loss_part_drydep_0001_aero_size_num.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_constant_part.spec; then continue; fi
+	  if ! ../../partmc run_constant_exact.spec; then continue; fi
+          if ! ../../partmc run_volume_part.spec; then continue; fi
+          if ! ../../partmc run_volume_exact.spec; then continue; fi
+          if ! ../../partmc run_drydep_part.spec; then continue; fi
+          if ! ../../partmc run_drydep_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/loss/test_loss_09.sh
+++ b/test/loss/test_loss_09.sh
@@ -7,7 +7,30 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_drydep_0001
-../../extract_sectional_aero_size --mass out/loss_exact_drydep
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.15 out/loss_exact_drydep_aero_size_mass.txt out/loss_part_drydep_0001_aero_size_mass.txt
+if ! ../../extract_aero_size --mass --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_drydep_0001 || \
+   ! ../../extract_sectional_aero_size --mass out/loss_exact_drydep || \
+   ! ../../numeric_diff --by col --rel-tol 0.15 out/loss_exact_drydep_aero_size_mass.txt out/loss_part_drydep_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_constant_part.spec; then continue; fi
+	  if ! ../../partmc run_constant_exact.spec; then continue; fi
+          if ! ../../partmc run_volume_part.spec; then continue; fi
+          if ! ../../partmc run_volume_exact.spec; then continue; fi
+          if ! ../../partmc run_drydep_part.spec; then continue; fi
+          if ! ../../partmc run_drydep_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/loss/test_loss_10.sh
+++ b/test/loss/test_loss_10.sh
@@ -9,10 +9,32 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_chamber_part.spec
-../../partmc run_chamber_exact.spec
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_time out/loss_part_chamber_0001
-../../extract_sectional_aero_time out/loss_exact_chamber
-
-../../numeric_diff --by col --rel-tol 0.15 out/loss_exact_chamber_aero_time.txt out/loss_part_chamber_0001_aero_time.txt
+if ! ../../partmc run_chamber_part.spec || \
+   ! ../../partmc run_chamber_exact.spec || \
+   ! ../../extract_aero_time out/loss_part_chamber_0001 || \
+   ! ../../extract_sectional_aero_time out/loss_exact_chamber || \
+   ! ../../numeric_diff --by col --rel-tol 0.15 out/loss_exact_chamber_aero_time.txt out/loss_part_chamber_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_constant_part.spec; then continue; fi
+	  if ! ../../partmc run_constant_exact.spec; then continue; fi
+          if ! ../../partmc run_volume_part.spec; then continue; fi
+          if ! ../../partmc run_volume_exact.spec; then continue; fi
+          if ! ../../partmc run_drydep_part.spec; then continue; fi
+          if ! ../../partmc run_drydep_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/loss/test_loss_11.sh
+++ b/test/loss/test_loss_11.sh
@@ -9,7 +9,32 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../extract_aero_size --num --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_chamber_0001
-../../extract_sectional_aero_size --num out/loss_exact_chamber
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.25 out/loss_exact_chamber_aero_size_num.txt out/loss_part_chamber_0001_aero_size_num.txt
+if ! ../../extract_aero_size --num --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_chamber_0001 || \
+   ! ../../extract_sectional_aero_size --num out/loss_exact_chamber || \
+   ! ../../numeric_diff --by col --rel-tol 0.25 out/loss_exact_chamber_aero_size_num.txt out/loss_part_chamber_0001_aero_size_num.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_constant_part.spec; then continue; fi
+	  if ! ../../partmc run_constant_exact.spec; then continue; fi
+          if ! ../../partmc run_volume_part.spec; then continue; fi
+          if ! ../../partmc run_volume_exact.spec; then continue; fi
+          if ! ../../partmc run_drydep_part.spec; then continue; fi
+          if ! ../../partmc run_drydep_exact.spec; then continue; fi
+          if ! ../../partmc run_chamber_part.spec; then continue; fi
+          if ! ../../partmc run_chamber_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/loss/test_loss_12.sh
+++ b/test/loss/test_loss_12.sh
@@ -7,7 +7,32 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_chamber_0001
-../../extract_sectional_aero_size --mass out/loss_exact_chamber
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.25 out/loss_exact_chamber_aero_size_mass.txt out/loss_part_chamber_0001_aero_size_mass.txt
+if ! ../../extract_aero_size --mass --dmin 1e-9 --dmax 1e-3 --nbin 160 out/loss_part_chamber_0001 || \
+   ! ../../extract_sectional_aero_size --mass out/loss_exact_chamber || \
+   ! ../../numeric_diff --by col --rel-tol 0.25 out/loss_exact_chamber_aero_size_mass.txt out/loss_part_chamber_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_constant_part.spec; then continue; fi
+	  if ! ../../partmc run_constant_exact.spec; then continue; fi
+          if ! ../../partmc run_volume_part.spec; then continue; fi
+          if ! ../../partmc run_volume_exact.spec; then continue; fi
+          if ! ../../partmc run_drydep_part.spec; then continue; fi
+          if ! ../../partmc run_drydep_exact.spec; then continue; fi
+          if ! ../../partmc run_chamber_part.spec; then continue; fi
+          if ! ../../partmc run_chamber_exact.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/mosaic/test_mosaic_1.sh
+++ b/test/mosaic/test_mosaic_1.sh
@@ -9,6 +9,24 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_part.spec
-../../extract_aero_time out/mosaic_0001
-../../numeric_diff --by col --rel-tol 0.4 ref_mosaic_0001_aero_time.txt out/mosaic_0001_aero_time.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../partmc run_part.spec || \
+   ! ../../extract_aero_time out/mosaic_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 0.4 ref_mosaic_0001_aero_time.txt out/mosaic_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/mosaic/test_mosaic_2.sh
+++ b/test/mosaic/test_mosaic_2.sh
@@ -7,5 +7,24 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_env out/mosaic_0001
-../../numeric_diff --by elem --rel-tol 1e-12 ref_mosaic_0001_env.txt out/mosaic_0001_env.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_env out/mosaic_0001 || \
+   ! ../../numeric_diff --by elem --rel-tol 1e-12 ref_mosaic_0001_env.txt out/mosaic_0001_env.txt &> /dev/null; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/mosaic/test_mosaic_3.sh
+++ b/test/mosaic/test_mosaic_3.sh
@@ -7,5 +7,24 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_gas out/mosaic_0001
-../../numeric_diff --by row --rel-tol 1e-4 ref_mosaic_0001_gas.txt out/mosaic_0001_gas.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_gas out/mosaic_0001 || \
+   ! ../../numeric_diff --by row --rel-tol 1e-4 ref_mosaic_0001_gas.txt out/mosaic_0001_gas.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/mosaic/test_mosaic_4.sh
+++ b/test/mosaic/test_mosaic_4.sh
@@ -7,9 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../partmc run_part_restarted.spec
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_time out/mosaic_restarted_0001
-tail -n +13 out/mosaic_0001_aero_time.txt > out/mosaic_0001_aero_time_tail.txt
-
-../../numeric_diff --by elem --min-col 2 --rel-tol 1e-4 out/mosaic_0001_aero_time_tail.txt out/mosaic_restarted_0001_aero_time.txt
+if ! ../../partmc run_part_restarted.spec || \
+   ! ../../extract_aero_time out/mosaic_restarted_0001 || \
+   ! tail -n +13 out/mosaic_0001_aero_time.txt > out/mosaic_0001_aero_time_tail.txt || \
+   ! ../../numeric_diff --by elem --min-col 2 --rel-tol 1e-4 out/mosaic_0001_aero_time_tail.txt out/mosaic_restarted_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/mosaic/test_mosaic_5.sh
+++ b/test/mosaic/test_mosaic_5.sh
@@ -7,7 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_env out/mosaic_restarted_0001
-tail -n +13 out/mosaic_0001_env.txt > out/mosaic_0001_env_tail.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by elem --min-col 2 --rel-tol 1e-6 out/mosaic_0001_env_tail.txt out/mosaic_restarted_0001_env.txt
+if ! ../../extract_env out/mosaic_restarted_0001 || \
+   ! tail -n +13 out/mosaic_0001_env.txt > out/mosaic_0001_env_tail.txt || \
+   ! ../../numeric_diff --by elem --min-col 2 --rel-tol 1e-6 out/mosaic_0001_env_tail.txt out/mosaic_restarted_0001_env.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+          if ! ../../partmc run_part_restarted.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/mosaic/test_mosaic_6.sh
+++ b/test/mosaic/test_mosaic_6.sh
@@ -7,7 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_gas out/mosaic_restarted_0001
-tail -n +13 out/mosaic_0001_gas.txt > out/mosaic_0001_gas_tail.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by elem --min-col 2 --rel-tol 1e-4 out/mosaic_0001_gas_tail.txt out/mosaic_restarted_0001_gas.txt
+if ! ../../extract_gas out/mosaic_restarted_0001 || \
+   ! tail -n +13 out/mosaic_0001_gas.txt > out/mosaic_0001_gas_tail.txt || \
+   ! ../../numeric_diff --by elem --min-col 2 --rel-tol 1e-4 out/mosaic_0001_gas_tail.txt out/mosaic_restarted_0001_gas.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+          if ! ../../partmc run_part_restarted.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/nucleate/test_nucleate_1.sh
+++ b/test/nucleate/test_nucleate_1.sh
@@ -9,7 +9,25 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_part.spec
-../../extract_aero_time out/nucleate_part_0001
-../../test_nucleate_ode
-../../numeric_diff --by col --min-col 1 --max-col 3 --rel-tol 0.15 out/nucleate_ode_aero_time.txt out/nucleate_part_0001_aero_time.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../partmc run_part.spec || \
+   ! ../../extract_aero_time out/nucleate_part_0001 || \
+   ! ../../test_nucleate_ode || \
+   ! ../../numeric_diff --by col --min-col 1 --max-col 3 --rel-tol 0.15 out/nucleate_ode_aero_time.txt out/nucleate_part_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/nucleate/test_nucleate_2.sh
+++ b/test/nucleate/test_nucleate_2.sh
@@ -7,5 +7,24 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_gas out/nucleate_part_0001
-../../numeric_diff --by col --rel-tol 0.05  out/nucleate_ode_gas.txt out/nucleate_part_0001_gas.txt
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../extract_gas out/nucleate_part_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 0.05  out/nucleate_ode_gas.txt out/nucleate_part_0001_gas.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/parallel/test_parallel_1.sh
+++ b/test/parallel/test_parallel_1.sh
@@ -9,16 +9,33 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-mpirun -v -np 1 ../../partmc run_sect.spec
-../../extract_sectional_aero_size --num out/sect
-../../extract_sectional_aero_size --mass out/sect
-../../extract_sectional_aero_time out/sect
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-mpirun -v -np 1 ../../partmc run_part_serial.spec
-../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 220 out/serial_0001
-../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 220 out/serial_0001
-../../extract_aero_time out/serial_0001
+if ! mpirun -v -np 1 ../../partmc run_sect.spec || \
+   ! ../../extract_sectional_aero_size --num out/sect || \
+   ! ../../extract_sectional_aero_size --mass out/sect || \
+   ! ../../extract_sectional_aero_time out/sect || \
 
-../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_size_num.txt out/serial_0001_aero_size_num.txt
-../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_size_mass.txt out/serial_0001_aero_size_mass.txt
-../../numeric_diff --by col --rel-tol 0.1 out/sect_aero_time.txt out/serial_0001_aero_time.txt
+   ! mpirun -v -np 1 ../../partmc run_part_serial.spec || \
+   ! ../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 220 out/serial_0001 || \
+   ! ../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 220 out/serial_0001 || \
+   ! ../../extract_aero_time out/serial_0001 || \
+
+   ! ../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_size_num.txt out/serial_0001_aero_size_num.txt || \
+   ! ../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_size_mass.txt out/serial_0001_aero_size_mass.txt || \
+   ! ../../numeric_diff --by col --rel-tol 0.1 out/sect_aero_time.txt out/serial_0001_aero_time.txt; then
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/parallel/test_parallel_2.sh
+++ b/test/parallel/test_parallel_2.sh
@@ -9,7 +9,22 @@ cd ${0%/*}
 
 parallel_type=dist
 
-mpirun -v -np 4 ../../partmc run_part_parallel_${parallel_type}.spec
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! mpirun -v -np 4 ../../partmc run_part_parallel_${parallel_type}.spec; then
+	echo Failure "$counter"
+	if [ "$counter" -gt 10 ]
+	then
+		echo FAIL
+		exit 1
+	fi
+	echo retrying...
+    	((counter++))
+fi
+
 for f in out/parallel_${parallel_type}_0001_????_00000001.nc ; do
     echo "####################################################################"
     echo "####################################################################"
@@ -19,9 +34,18 @@ for f in out/parallel_${parallel_type}_0001_????_00000001.nc ; do
     ../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 220 ${prefix}
     ../../extract_aero_time ${prefix}
     
-    ../../numeric_diff --by col --rel-tol 0.4 out/sect_aero_size_num.txt ${prefix}_aero_size_num.txt
-    ../../numeric_diff --by col --rel-tol 0.4 out/sect_aero_size_mass.txt ${prefix}_aero_size_mass.txt
-    ../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_time.txt ${prefix}_aero_time.txt
+    if ! ../../numeric_diff --by col --rel-tol 0.4 out/sect_aero_size_num.txt ${prefix}_aero_size_num.txt || \
+       ! ../../numeric_diff --by col --rel-tol 0.4 out/sect_aero_size_mass.txt ${prefix}_aero_size_mass.txt || \
+       ! ../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_time.txt ${prefix}_aero_time.txt; then 
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+    	  ((counter++))
+    fi
 done
 
 # #######################################################################
@@ -32,6 +56,19 @@ done
 ../../numeric_average out/parallel_${parallel_type}_aero_size_mass.txt out/parallel_${parallel_type}_0001_????_aero_size_mass.txt
 ../../numeric_average out/parallel_${parallel_type}_aero_time.txt out/parallel_${parallel_type}_0001_????_aero_time.txt
 
-../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_size_num.txt out/parallel_${parallel_type}_aero_size_num.txt
-../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_size_mass.txt out/parallel_${parallel_type}_aero_size_mass.txt
-../../numeric_diff --by col --rel-tol 0.1 out/sect_aero_time.txt out/parallel_${parallel_type}_aero_time.txt
+if ! ../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_size_num.txt out/parallel_${parallel_type}_aero_size_num.txt || \
+   ! ../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_size_mass.txt out/parallel_${parallel_type}_aero_size_mass.txt || \
+   ! ../../numeric_diff --by col --rel-tol 0.1 out/sect_aero_time.txt out/parallel_${parallel_type}_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/parallel/test_parallel_4.sh
+++ b/test/parallel/test_parallel_4.sh
@@ -7,11 +7,28 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-mpirun -v -np 4 ../../partmc run_part_parallel_dist_single.spec
-../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 220 out/parallel_dist_single_0001
-../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 220 out/parallel_dist_single_0001
-../../extract_aero_time out/parallel_dist_single_0001
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_size_num.txt out/parallel_dist_single_0001_aero_size_num.txt
-../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_size_mass.txt out/parallel_dist_single_0001_aero_size_mass.txt
-../../numeric_diff --by col --rel-tol 0.1 out/sect_aero_time.txt out/parallel_dist_single_0001_aero_time.txt
+if ! mpirun -v -np 4 ../../partmc run_part_parallel_dist_single.spec || \
+   ! ../../extract_aero_size --num --dmin 1e-10 --dmax 1e-4 --nbin 220 out/parallel_dist_single_0001 || \
+   ! ../../extract_aero_size --mass --dmin 1e-10 --dmax 1e-4 --nbin 220 out/parallel_dist_single_0001 || \
+   ! ../../extract_aero_time out/parallel_dist_single_0001 || \
+   ! ../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_size_num.txt out/parallel_dist_single_0001_aero_size_num.txt || \
+   ! ../../numeric_diff --by col --rel-tol 0.2 out/sect_aero_size_mass.txt out/parallel_dist_single_0001_aero_size_mass.txt || \
+   ! ../../numeric_diff --by col --rel-tol 0.1 out/sect_aero_time.txt out/parallel_dist_single_0001_aero_time.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/rand/test_rand_1.sh
+++ b/test/rand/test_rand_1.sh
@@ -9,6 +9,24 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../test_poisson_sample 1 50 10000000 > out/poisson_1_approx.dat
-../../test_poisson_sample 1 50 0        > out/poisson_1_exact.dat
-../../numeric_diff --by col --rel-tol 1e-3 out/poisson_1_exact.dat out/poisson_1_approx.dat
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../test_poisson_sample 1 50 10000000 > out/poisson_1_approx.dat || \
+   ! ../../test_poisson_sample 1 50 0        > out/poisson_1_exact.dat || \
+   ! ../../numeric_diff --by col --rel-tol 1e-3 out/poisson_1_exact.dat out/poisson_1_approx.dat; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/rand/test_rand_2.sh
+++ b/test/rand/test_rand_2.sh
@@ -7,6 +7,24 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../test_poisson_sample 4 50 10000000 > out/poisson_4_approx.dat
-../../test_poisson_sample 4 50 0        > out/poisson_4_exact.dat
-../../numeric_diff --by col --rel-tol 2e-3 out/poisson_4_exact.dat out/poisson_4_approx.dat
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../test_poisson_sample 4 50 10000000 > out/poisson_4_approx.dat || \
+   ! ../../test_poisson_sample 4 50 0        > out/poisson_4_exact.dat || \
+   ! ../../numeric_diff --by col --rel-tol 2e-3 out/poisson_4_exact.dat out/poisson_4_approx.dat; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/rand/test_rand_3.sh
+++ b/test/rand/test_rand_3.sh
@@ -7,6 +7,24 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../test_poisson_sample 10 50 10000000 > out/poisson_10_approx.dat
-../../test_poisson_sample 10 50 0        > out/poisson_10_exact.dat
-../../numeric_diff --by col --rel-tol 2e-3 out/poisson_10_exact.dat out/poisson_10_approx.dat
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../test_poisson_sample 10 50 10000000 > out/poisson_10_approx.dat || \
+   ! ../../test_poisson_sample 10 50 0        > out/poisson_10_exact.dat || \
+   ! ../../numeric_diff --by col --rel-tol 2e-3 out/poisson_10_exact.dat out/poisson_10_approx.dat; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/rand/test_rand_4.sh
+++ b/test/rand/test_rand_4.sh
@@ -7,6 +7,24 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../test_poisson_sample 20 50 10000000 > out/poisson_20_approx.dat
-../../test_poisson_sample 20 50 0        > out/poisson_20_exact.dat
-../../numeric_diff --by col --rel-tol 0.07 out/poisson_20_exact.dat out/poisson_20_approx.dat
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../test_poisson_sample 20 50 10000000 > out/poisson_20_approx.dat || \
+   ! ../../test_poisson_sample 20 50 0        > out/poisson_20_exact.dat || \
+   ! ../../numeric_diff --by col --rel-tol 0.07 out/poisson_20_exact.dat out/poisson_20_approx.dat; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/rand/test_rand_5.sh
+++ b/test/rand/test_rand_5.sh
@@ -7,6 +7,24 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../test_poisson_sample 30 50 10000000 > out/poisson_30_approx.dat
-../../test_poisson_sample 30 50 0        > out/poisson_30_exact.dat
-../../numeric_diff --by col --rel-tol 0.06 out/poisson_30_exact.dat out/poisson_30_approx.dat
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../test_poisson_sample 30 50 10000000 > out/poisson_30_approx.dat || \
+   ! ../../test_poisson_sample 30 50 0        > out/poisson_30_exact.dat || \
+   ! ../../numeric_diff --by col --rel-tol 0.06 out/poisson_30_exact.dat out/poisson_30_approx.dat; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/rand/test_rand_6.sh
+++ b/test/rand/test_rand_6.sh
@@ -9,6 +9,24 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../test_binomial_sample 10 0.3 10000000 > out/binomial_1_approx.dat
-../../test_binomial_sample 10 0.3 0        > out/binomial_1_exact.dat
-../../numeric_diff --by col --rel-tol 1e-3 out/binomial_1_exact.dat out/binomial_1_approx.dat
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../test_binomial_sample 10 0.3 10000000 > out/binomial_1_approx.dat || \
+   ! ../../test_binomial_sample 10 0.3 0        > out/binomial_1_exact.dat || \
+   ! ../../numeric_diff --by col --rel-tol 1e-3 out/binomial_1_exact.dat out/binomial_1_approx.dat; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/rand/test_rand_7.sh
+++ b/test/rand/test_rand_7.sh
@@ -9,6 +9,24 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../test_binomial_sample 10 0.7 10000000 > out/binomial_2_approx.dat
-../../test_binomial_sample 10 0.7 0        > out/binomial_2_exact.dat
-../../numeric_diff --by col --rel-tol 2e-3 out/binomial_2_exact.dat out/binomial_2_approx.dat
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../test_binomial_sample 10 0.7 10000000 > out/binomial_2_approx.dat || \
+   ! ../../test_binomial_sample 10 0.7 0        > out/binomial_2_exact.dat || \
+   ! ../../numeric_diff --by col --rel-tol 2e-3 out/binomial_2_exact.dat out/binomial_2_approx.dat; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/rand/test_rand_8.sh
+++ b/test/rand/test_rand_8.sh
@@ -9,6 +9,24 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../test_binomial_sample 30 0.5 10000000 > out/binomial_3_approx.dat
-../../test_binomial_sample 30 0.5 0        > out/binomial_3_exact.dat
-../../numeric_diff --by col --rel-tol 5e-3 out/binomial_3_exact.dat out/binomial_3_approx.dat
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
+
+if ! ../../test_binomial_sample 30 0.5 10000000 > out/binomial_3_approx.dat || \
+   ! ../../test_binomial_sample 30 0.5 0        > out/binomial_3_exact.dat || \
+   ! ../../numeric_diff --by col --rel-tol 5e-3 out/binomial_3_exact.dat out/binomial_3_approx.dat; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/sedi/test_sedi_1.sh
+++ b/test/sedi/test_sedi_1.sh
@@ -9,10 +9,26 @@ cd ${0%/*}
 # make the output directory if it doesn't exist
 mkdir -p out
 
-../../partmc run_part.spec
-../../partmc run_sect.spec
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../extract_aero_size --num --dmin 1e-7 --dmax 1 --nbin 100 out/sedi_part_0001
-../../extract_sectional_aero_size --num out/sedi_sect
-
-../../numeric_diff --by col --rel-tol 0.7 out/sedi_sect_aero_size_num.txt out/sedi_part_0001_aero_size_num.txt
+if ! ../../partmc run_part.spec || \
+   ! ../../partmc run_sect.spec || \
+   ! ../../extract_aero_size --num --dmin 1e-7 --dmax 1 --nbin 100 out/sedi_part_0001 || \
+   ! ../../extract_sectional_aero_size --num out/sedi_sect || \
+   ! ../../numeric_diff --by col --rel-tol 0.7 out/sedi_sect_aero_size_num.txt out/sedi_part_0001_aero_size_num.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done

--- a/test/sedi/test_sedi_2.sh
+++ b/test/sedi/test_sedi_2.sh
@@ -7,7 +7,26 @@ set -v
 # make sure that the current directory is the one where this script is
 cd ${0%/*}
 
-../../extract_aero_size --mass --dmin 1e-7 --dmax 1 --nbin 100 out/sedi_part_0001
-../../extract_sectional_aero_size --mass out/sedi_sect
+((counter = 1))
+while [ true ]
+do
+  echo Attempt $counter
 
-../../numeric_diff --by col --rel-tol 0.7 out/sedi_sect_aero_size_mass.txt out/sedi_part_0001_aero_size_mass.txt
+if ! ../../extract_aero_size --mass --dmin 1e-7 --dmax 1 --nbin 100 out/sedi_part_0001 || \
+   ! ../../extract_sectional_aero_size --mass out/sedi_sect || \
+   ! ../../numeric_diff --by col --rel-tol 0.7 out/sedi_sect_aero_size_mass.txt out/sedi_part_0001_aero_size_mass.txt; then
+	  echo Failure "$counter"
+	  if [ "$counter" -gt 10 ]
+	  then
+		  echo FAIL
+		  exit 1
+	  fi
+	  echo retrying...
+	  if ! ../../partmc run_part.spec; then continue; fi
+	  if ! ../../partmc run_sect.spec; then continue; fi
+  else
+	  echo PASS
+	  exit 0
+  fi
+  ((counter++))
+done


### PR DESCRIPTION
Added 10 retries for each integration test in their bash scripts. If tests fail in the future, it may be because the retry loop is not rerunning all the analyses from previous tests that the current (failing) test depends on.