### PR TITLE
merge in WRF-PartMC code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ scenarios/3_condense/spec/
 scenarios/3_condense/temp/
 scenarios/3_condense/out/
 scenarios/4_chamber/out/
+*.o
+*.mod

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,186 @@
+#
+
+LN      =       ln -sf
+MAKE    =       make -i -r
+RM      =       rm -f
+
+PMC_MODULES =                           \
+  aero_binned.o                 \
+  aero_data.o                   \
+  aero_dist.o                   \
+  aero_info.o                   \
+  aero_info_array.o             \
+  aero_mode.o                   \
+  aero_particle.o               \
+  aero_particle_array.o         \
+  aero_state.o                  \
+  aero_sorted.o                 \
+  aero_weight.o                 \
+  aero_weight_array.o           \
+  bin_grid.o                    \
+  coag_kernel.o                 \
+  coag_kernel_additive.o        \
+  coag_kernel_brown.o           \
+  coag_kernel_brown_cont.o      \
+  coag_kernel_brown_free.o      \
+  coag_kernel_constant.o        \
+  coag_kernel_sedi.o            \
+  coag_kernel_zero.o            \
+  coagulation.o                 \
+  coagulation_dist.o            \
+  constants.o                   \
+  env_data.o                    \
+  env_state.o                   \
+  fractal.o                     \
+  gas_data.o                    \
+  gas_state.o                   \
+  integer_rmap.o                \
+  integer_rmap2.o               \
+  integer_varray.o              \
+  mosaic.o                      \
+  mpi.o                         \
+  netcdf.o                      \
+  nucleate.o                    \
+  output.o                      \
+  rand.o                        \
+  scenario.o                    \
+  spec_file.o                   \
+  spec_line.o                   \
+  stats.o                       \
+  util.o                        \
+
+OBJS = \
+ 
+LIBTARGET    =  partmcmosaic
+TARGETDIR    =  ./
+$(LIBTARGET) :  $(MODULES) $(PMC_MODULES) $(OBJS)
+		$(AR) $(ARFLAGS) $(MODULES) $(PMC_MODULES) \
+		$(OBJS)
+
+include ../../WRFV3/configure.wrf
+
+all: pmc 
+
+pmc: $(PMC_MODULES)
+
+clean:
+	@ echo 'use the clean script'
+
+# DEPENDENCIES : only dependencies after this line (don't remove the word DEPENDENCIES)
+
+aero_binned.o: bin_grid.o aero_particle.o spec_file.o \
+     util.o aero_dist.o mpi.o aero_data.o
+
+aero_data.o: spec_file.o mpi.o util.o fractal.o netcdf.o
+
+aero_dist.o: bin_grid.o util.o constants.o spec_file.o \
+     aero_data.o aero_mode.o mpi.o rand.o
+
+aero_info.o: util.o spec_file.o mpi.o
+
+aero_info_array.o: aero_info.o util.o spec_file.o mpi.o
+
+aero_mode.o: bin_grid.o util.o constants.o spec_file.o \
+     aero_data.o aero_weight.o mpi.o rand.o
+
+aero_particle.o: util.o aero_data.o spec_file.o env_state.o \
+     mpi.o
+
+aero_particle_array.o: aero_particle.o util.o spec_file.o mpi.o
+
+aero_sorted.o: integer_varray.o integer_rmap.o integer_rmap2.o \
+     aero_particle.o aero_particle_array.o bin_grid.o mpi.o
+
+aero_state.o: aero_particle_array.o aero_sorted.o integer_varray.o \
+     bin_grid.o aero_data.o aero_particle.o aero_dist.o \
+     util.o rand.o aero_binned.o mpi.o spec_file.o \
+     aero_info.o aero_info_array.o aero_weight.o \
+     aero_weight_array.o
+
+aero_weight.o: util.o constants.o rand.o spec_file.o \
+     aero_particle.o aero_data.o netcdf.o mpi.o
+
+aero_weight_array.o: util.o constants.o rand.o spec_file.o \
+     aero_particle.o netcdf.o mpi.o aero_weight.o aero_data.o
+
+bin_grid.o: constants.o util.o spec_file.o mpi.o netcdf.o
+
+coag_kernel.o: env_state.o bin_grid.o aero_particle.o \
+     aero_data.o aero_weight.o aero_weight_array.o coag_kernel_sedi.o \
+     coag_kernel_additive.o coag_kernel_constant.o \
+     coag_kernel_brown.o coag_kernel_zero.o \
+     coag_kernel_brown_free.o coag_kernel_brown_cont.o
+
+coag_kernel_additive.o: bin_grid.o env_state.o util.o \
+     constants.o aero_binned.o aero_data.o aero_dist.o \
+     aero_particle.o
+
+coag_kernel_brown.o: env_state.o constants.o util.o \
+     aero_particle.o
+
+coag_kernel_brown_cont.o: env_state.o constants.o util.o \
+    aero_particle.o aero_data.o
+
+coag_kernel_brown_free.o: env_state.o constants.o util.o \
+    aero_particle.o aero_data.o
+
+coag_kernel_constant.o: env_state.o bin_grid.o util.o \
+     constants.o aero_binned.o aero_data.o aero_dist.o \
+     aero_data.o aero_particle.o
+
+coag_kernel_sedi.o: env_state.o constants.o aero_data.o \
+     aero_particle.o
+
+coag_kernel_zero.o: bin_grid.o env_state.o util.o aero_binned.o \
+     aero_dist.o aero_data.o aero_particle.o scenario.o
+
+coagulation.o: bin_grid.o aero_data.o util.o env_state.o \
+     aero_state.o aero_weight.o mpi.o coag_kernel.o \
+     aero_sorted.o
+
+coagulation_dist.o: bin_grid.o aero_data.o util.o env_state.o \
+     aero_state.o coagulation.o mpi.o
+
+constants.o: constants.F90
+
+env_data.o: gas_state.o aero_dist.o util.o env_state.o \
+     spec_file.o aero_data.o gas_data.o mpi.o
+
+env_state.o: constants.o util.o spec_file.o mpi.o netcdf.o
+
+fractal.o: spec_file.o constants.o netcdf.o mpi.o
+
+gas_data.o: spec_file.o mpi.o util.o netcdf.o
+
+gas_state.o:util.o spec_file.o gas_data.o mpi.o netcdf.o
+
+integer_rmap.o: integer_varray.o util.o mpi.o
+
+integer_rmap2.o: integer_varray.o util.o mpi.o
+
+integer_varray.o: util.o mpi.o
+
+mosaic.o: aero_data.o aero_state.o constants.o env_state.o \
+     gas_data.o gas_state.o util.o
+
+mpi.o: util.o
+
+netcdf.o: util.o
+
+nucleate.o: env_state.o aero_state.o aero_data.o gas_data.o gas_state.o
+
+output.o: bin_grid.o aero_data.o aero_state.o aero_binned.o \
+     netcdf.o env_state.o util.o gas_data.o mpi.o
+
+rand.o: util.o constants.o mpi.o
+
+scenario.o: gas_state.o aero_dist.o util.o env_state.o \
+     aero_state.o spec_file.o aero_data.o gas_data.o mpi.o
+
+spec_file.o: spec_line.o util.o
+
+spec_line.o: util.o
+
+stats.o:   util.o netcdf.o
+
+util.o: constants.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -135,13 +135,13 @@ coag_kernel_zero.o: bin_grid.o env_state.o util.o aero_binned.o \
      aero_dist.o aero_data.o aero_particle.o scenario.o
 
 coagulation.o: bin_grid.o aero_data.o util.o env_state.o \
-     aero_state.o aero_weight.o mpi.o coag_kernel.o \
+     aero_state.o aero_weight.o mpi.o coag_kernel.o stats.o \
      aero_sorted.o
 
 coagulation_dist.o: bin_grid.o aero_data.o util.o env_state.o \
      aero_state.o coagulation.o mpi.o
 
-constants.o: constants.F90
+constants.o:
 
 env_state.o: constants.o util.o spec_file.o mpi.o netcdf.o
 
@@ -149,7 +149,7 @@ fractal.o: spec_file.o constants.o netcdf.o mpi.o
 
 gas_data.o: spec_file.o mpi.o util.o netcdf.o
 
-gas_state.o:util.o spec_file.o gas_data.o mpi.o netcdf.o
+gas_state.o:util.o spec_file.o gas_data.o mpi.o netcdf.o env_state.o
 
 integer_rmap.o: integer_varray.o util.o mpi.o
 
@@ -162,7 +162,7 @@ mosaic.o: aero_data.o aero_state.o constants.o env_state.o \
 
 mpi.o: util.o
 
-netcdf.o: util.o
+netcdf.o: util.o rand.o
 #	mpif90 -c netcdf.F90 -I/data/keeling/a/jcurtis2/support/netcdf4-4.1.2/include/
 
 nucleate.o: env_state.o aero_state.o aero_data.o gas_data.o gas_state.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -29,7 +29,6 @@ PMC_MODULES =                           \
   coagulation.o                 \
   coagulation_dist.o            \
   constants.o                   \
-  env_data.o                    \
   env_state.o                   \
   fractal.o                     \
   gas_data.o                    \
@@ -51,11 +50,12 @@ PMC_MODULES =                           \
 
 OBJS = \
  
-LIBTARGET    =  partmcmosaic
+LIBTARGET    =  libpartmc.a
 TARGETDIR    =  ./
 $(LIBTARGET) :  $(MODULES) $(PMC_MODULES) $(OBJS)
-		$(AR) $(ARFLAGS) $(MODULES) $(PMC_MODULES) \
+		$(AR) $(ARFLAGS) $(LIBTARGET) $(MODULES) $(PMC_MODULES) \
 		$(OBJS)
+		$(RANLIB) $(RANLIBFLAGS) $@
 
 include ../../WRFV3/configure.wrf
 
@@ -143,9 +143,6 @@ coagulation_dist.o: bin_grid.o aero_data.o util.o env_state.o \
 
 constants.o: constants.F90
 
-env_data.o: gas_state.o aero_dist.o util.o env_state.o \
-     spec_file.o aero_data.o gas_data.o mpi.o
-
 env_state.o: constants.o util.o spec_file.o mpi.o netcdf.o
 
 fractal.o: spec_file.o constants.o netcdf.o mpi.o
@@ -166,6 +163,7 @@ mosaic.o: aero_data.o aero_state.o constants.o env_state.o \
 mpi.o: util.o
 
 netcdf.o: util.o
+#	mpif90 -c netcdf.F90 -I/data/keeling/a/jcurtis2/support/netcdf4-4.1.2/include/
 
 nucleate.o: env_state.o aero_state.o aero_data.o gas_data.o gas_state.o
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,6 +18,7 @@ PMC_MODULES =                           \
   aero_weight.o                 \
   aero_weight_array.o           \
   bin_grid.o                    \
+  chamber.o                     \
   coag_kernel.o                 \
   coag_kernel_additive.o        \
   coag_kernel_brown.o           \
@@ -105,6 +106,8 @@ aero_weight_array.o: util.o constants.o rand.o spec_file.o \
 
 bin_grid.o: constants.o util.o spec_file.o mpi.o netcdf.o
 
+chamber.o: aero_data.o constants.o env_state.o spec_file.o
+
 coag_kernel.o: env_state.o bin_grid.o aero_particle.o \
      aero_data.o aero_weight.o aero_weight_array.o coag_kernel_sedi.o \
      coag_kernel_additive.o coag_kernel_constant.o \
@@ -173,7 +176,7 @@ output.o: bin_grid.o aero_data.o aero_state.o aero_binned.o \
 rand.o: util.o constants.o mpi.o
 
 scenario.o: gas_state.o aero_dist.o util.o env_state.o \
-     aero_state.o spec_file.o aero_data.o gas_data.o mpi.o
+     aero_state.o spec_file.o aero_data.o gas_data.o mpi.o chamber.o
 
 spec_file.o: spec_line.o util.o
 

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -837,15 +837,9 @@ contains
     call aero_state_copy_weight(aero_state_from, aero_state_to)
 #endif
 
-#ifdef PMC_DEBUG
-    n_parts_before = aero_state_total_particles(aero_state_to)
-#endif
     n_transfer = rand_binomial(aero_state_total_particles(aero_state_from), &
          sample_prob)
     i_transfer = 0
-#ifdef PMC_DEBUG
-    print*, 'n_transfer = ', n_transfer, sample_prob
-#endif
     do while (i_transfer < n_transfer)
        if (aero_state_total_particles(aero_state_from) <= 0) exit
        call aero_state_rand_particle(aero_state_from, i_part)
@@ -853,11 +847,6 @@ contains
             aero_state_from%apa%particle(i_part), aero_data)
        num_conc_to = aero_weight_array_num_conc(aero_state_to%awa, &
             aero_state_from%apa%particle(i_part), aero_data)
-       if (num_conc_from > 100*num_conc_to) then
-          print*, "WARNING ", 'from: ', num_conc_from, 'to: ', num_conc_to, &
-             'group/class', aero_state_from%apa%particle(i_part)%weight_group, &
-             aero_state_from%apa%particle(i_part)%weight_class
-       end if
        if (num_conc_to == num_conc_from) then ! add and remove
           do_add = .true.
           do_remove = .true.
@@ -896,12 +885,6 @@ contains
           i_transfer = i_transfer + 1
        end if
     end do
-
-#ifdef PMC_DEBUG
-    print*, 'aero_state_sample_particles: aero_state_to contains', &
-         aero_state_total_particles(aero_state_to), ' particles and gained', &
-         aero_state_total_particles(aero_state_to) - n_parts_before
-#endif
 
   end subroutine aero_state_sample_particles
 
@@ -1682,9 +1665,6 @@ contains
             weight_ratio)
        n_remove = prob_round(real(n_part, kind=dp) &
             * (1d0 - 1d0 / weight_ratio))
-#ifdef PMC_DEBUG
-       print*, 'n_remove', n_remove, 'n_part', n_part, weight_ratio
-#endif
        do i_remove = 1,n_remove
           i_entry = pmc_rand_int(integer_varray_n_entry( &
                aero_state%aero_sorted%group_class%inverse(i_group, i_class)))

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -1578,7 +1578,7 @@ contains
              global_n_part &
                   = aero_state_total_particles_all_procs(aero_state, i_group, &
                   i_class)
-#endif;
+#endif
              do while ((real(global_n_part, kind=dp) &
                   < aero_state%n_part_ideal(i_group, i_class) / 2d0) &
                   .and. (global_n_part > 0))

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -843,7 +843,9 @@ contains
     n_transfer = rand_binomial(aero_state_total_particles(aero_state_from), &
          sample_prob)
     i_transfer = 0
+#ifdef PMC_DEBUG
     print*, 'n_transfer = ', n_transfer, sample_prob
+#endif
     do while (i_transfer < n_transfer)
        if (aero_state_total_particles(aero_state_from) <= 0) exit
        call aero_state_rand_particle(aero_state_from, i_part)
@@ -851,13 +853,11 @@ contains
             aero_state_from%apa%particle(i_part), aero_data)
        num_conc_to = aero_weight_array_num_conc(aero_state_to%awa, &
             aero_state_from%apa%particle(i_part), aero_data)
-#ifdef PMC_DEBUG
-       if (num_conc_to*100 > num_conc_from .or. num_conc_from > 100*num_conc_to) then
+       if (num_conc_from > 100*num_conc_to) then
           print*, "WARNING ", 'from: ', num_conc_from, 'to: ', num_conc_to, &
              'group/class', aero_state_from%apa%particle(i_part)%weight_group, &
              aero_state_from%apa%particle(i_part)%weight_class
        end if
-#endif
        if (num_conc_to == num_conc_from) then ! add and remove
           do_add = .true.
           do_remove = .true.

--- a/src/constants.F90
+++ b/src/constants.F90
@@ -26,6 +26,8 @@ module pmc_constants
   type const_t
      !> Pi.
      real(kind=dp) :: pi = 3.14159265358979323846d0
+     !> Acceleration due to gravity (m s^{-2}).
+     real(kind=dp) :: grav = 9.81d0
      !> Boltzmann constant (J K^{-1}).
      real(kind=dp) :: boltzmann = 1.3806505d-23
      !> Avogadro's number (mole^{-1}).

--- a/src/env_state.F90
+++ b/src/env_state.F90
@@ -565,6 +565,15 @@ contains
     call pmc_nc_read_real(ncid, env_state%longitude, "longitude")
     call pmc_nc_read_real(ncid, env_state%latitude, "latitude")
     call pmc_nc_read_real(ncid, env_state%altitude, "altitude")
+#ifdef PMC_USE_WRF
+    call pmc_nc_read_real(ncid, env_state%z_min, "bottom_boundary_altitude")
+    call pmc_nc_read_real(ncid, env_state%z_max, "top_boundary_altitude")
+    call pmc_nc_read_real(ncid, env_state%rrho, "specific_volume")
+    call pmc_nc_read_integer(ncid,env_state%ix,"x_index")
+    call pmc_nc_read_integer(ncid,env_state%iy,"y_index")
+    call pmc_nc_read_integer(ncid,env_state%iz,"z_index")
+    call pmc_nc_read_real(ncid, env_state%diff_coef, "eddy_diff")
+#endif
     call pmc_nc_read_real(ncid, env_state%start_time, &
          "start_time_of_day")
     call pmc_nc_read_integer(ncid, env_state%start_day, &

--- a/src/mpi.F90
+++ b/src/mpi.F90
@@ -944,7 +944,7 @@ contains
        call pmc_mpi_pack_integer(buffer, position, n4)
        call pmc_mpi_pack_integer(buffer, position, n5)
        call mpi_pack(val, n1*n2*n3*n4*n5, MPI_DOUBLE_PRECISION, buffer, &
-            position, MPI_COMM_WORLD, ierr)
+            size(buffer), position, MPI_COMM_WORLD, ierr)
        call pmc_mpi_check_ierr(ierr)
     end if
     call assert(567349745, &

--- a/src/mpi.F90
+++ b/src/mpi.F90
@@ -556,6 +556,38 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+  !> Determines the number of bytes required to pack the given value.
+  integer function pmc_mpi_pack_size_real_array_3d(val)
+
+    !> Value to pack.
+    real(kind=dp), allocatable, intent(in) :: val(:,:,:)
+
+    integer :: ierr, total_size
+
+#ifdef PMC_USE_MPI
+    logical :: is_allocated
+
+    total_size = 0
+    is_allocated = allocated(val)
+    if (is_allocated) then
+       call mpi_pack_size(size(val), MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, &
+            total_size, ierr)
+       call pmc_mpi_check_ierr(ierr)
+       total_size = total_size + pmc_mpi_pack_size_integer(size(val,1)) &
+         + pmc_mpi_pack_size_integer(size(val,2)) &
+         + pmc_mpi_pack_size_integer(size(val,3))
+    end if
+    total_size = total_size + pmc_mpi_pack_size_logical(is_allocated)
+#else
+    total_size = 0
+#endif
+
+    pmc_mpi_pack_size_real_array_3d = total_size
+
+  end function pmc_mpi_pack_size_real_array_3d
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
   !> Packs the given value into the buffer, advancing position.
   subroutine pmc_mpi_pack_integer(buffer, position, val)
 
@@ -813,6 +845,42 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+  !> Packs the given value into the buffer, advancing position.
+  subroutine pmc_mpi_pack_real_array_3d(buffer, position, val)
+
+    !> Memory buffer.
+    character, intent(inout) :: buffer(:)
+    !> Current buffer position.
+    integer, intent(inout) :: position
+    !> Value to pack.
+    real(kind=dp), allocatable, intent(in) :: val(:,:,:)
+
+#ifdef PMC_USE_MPI
+    integer :: prev_position, n1, n2, n3, ierr
+    logical :: is_allocated
+
+    prev_position = position
+    is_allocated = allocated(val)
+    call pmc_mpi_pack_logical(buffer, position, is_allocated)
+    if (is_allocated) then
+       n1 = size(val, 1)
+       n2 = size(val, 2)
+       n3 = size(val, 3)
+       call pmc_mpi_pack_integer(buffer, position, n1)
+       call pmc_mpi_pack_integer(buffer, position, n2)
+       call pmc_mpi_pack_integer(buffer, position, n3)
+       call mpi_pack(val, n1*n2*n3, MPI_DOUBLE_PRECISION, buffer, size(buffer), &
+            position, MPI_COMM_WORLD, ierr)
+       call pmc_mpi_check_ierr(ierr)
+    end if
+    call assert(567349745, &
+         position - prev_position <= pmc_mpi_pack_size_real_array_3d(val))
+#endif
+
+  end subroutine pmc_mpi_pack_real_array_3d
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
   !> Unpacks the given value from the buffer, advancing position.
   subroutine pmc_mpi_unpack_integer(buffer, position, val)
 
@@ -1067,6 +1135,40 @@ contains
 #endif
 
   end subroutine pmc_mpi_unpack_real_array_2d
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Unpacks the given value from the buffer, advancing position.
+  subroutine pmc_mpi_unpack_real_array_3d(buffer, position, val)
+
+    !> Memory buffer.
+    character, intent(inout) :: buffer(:)
+    !> Current buffer position.
+    integer, intent(inout) :: position
+    !> Value to pack.
+    real(kind=dp), allocatable, intent(inout) :: val(:,:,:)
+
+#ifdef PMC_USE_MPI
+    integer :: prev_position, n1, n2, n3, ierr
+    logical :: is_allocated
+
+    prev_position = position
+    call pmc_mpi_unpack_logical(buffer, position, is_allocated)
+    if (allocated(val)) deallocate(val)
+    if (is_allocated) then
+       call pmc_mpi_unpack_integer(buffer, position, n1)
+       call pmc_mpi_unpack_integer(buffer, position, n2)
+       call pmc_mpi_unpack_integer(buffer, position, n3)
+       allocate(val(n1,n2,n3))
+       call mpi_unpack(buffer, size(buffer), position, val, n1*n2*n3, &
+            MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, ierr)
+       call pmc_mpi_check_ierr(ierr)
+    end if
+    call assert(781681739, position - prev_position &
+         <= pmc_mpi_pack_size_real_array_3d(val))
+#endif
+
+  end subroutine pmc_mpi_unpack_real_array_3d
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/netcdf.F90
+++ b/src/netcdf.F90
@@ -736,4 +736,187 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+  !> Read a real 4D array from a NetCDF file.
+  subroutine pmc_nc_get_4d_var_real(ncid, var, name, must_be_present)
+
+    !> NetCDF file ID, in data mode.
+    integer, intent(in) :: ncid
+    !> Data to read.
+    real(kind=dp), allocatable, intent(out) :: var(:,:,:,:)
+    !> Variable name in NetCDF file.
+    character(len=*), intent(in) :: name
+    !> Whether the variable must be present in the NetCDF file
+    !> (default .true.).
+    logical, optional, intent(in) :: must_be_present
+
+    integer :: varid, status
+    logical :: use_must_be_present
+    integer :: dimids(4)
+    integer :: dim_size(4)
+    integer :: dim
+
+    if (present(must_be_present)) then
+       use_must_be_present = must_be_present
+    else
+       use_must_be_present = .true.
+    end if
+    status = nf90_inq_varid(ncid, name, varid)
+    if ((.not. use_must_be_present) .and. (status == NF90_ENOTVAR)) then
+       ! variable was not present, but that's ok
+       var = 0d0
+       return
+    end if
+
+    ! Find the varid
+    status = nf90_inq_varid(ncid, name, varid)
+    ! Inquire for the dimension IDs
+    call pmc_nc_check(nf90_inquire_variable(ncid, varid, dimids=dimids))
+    ! Loop over all the dimensions to get their lengths
+    do dim = 1, 4
+       call pmc_nc_check(nf90_inquire_dimension(ncid, dimids(dim), &
+            len=dim_size(dim)))
+    end do
+
+    ! Now allocate an array to hold the value
+    if (allocated(var)) deallocate(var)
+    allocate(var(dim_size(1),dim_size(2),dim_size(3),dim_size(4)))
+    call pmc_nc_check(nf90_get_var(ncid,varid,values=var))
+
+  end subroutine pmc_nc_get_4d_var_real
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Read a integer 4D array from a NetCDF file.
+  subroutine pmc_nc_get_4d_var_int(ncid, var, name, must_be_present)
+
+    !> NetCDF file ID, in data mode.
+    integer, intent(in) :: ncid
+    !> Data to read.
+    integer, allocatable, intent(out) :: var(:,:,:,:)
+    !> Variable name in NetCDF file.
+    character(len=*), intent(in) :: name
+    !> Whether the variable must be present in the NetCDF file
+    !> (default .true.).
+    logical, optional, intent(in) :: must_be_present
+
+    integer :: varid, status
+    logical :: use_must_be_present
+    integer :: dimids(4)
+    integer :: dim_size(4)
+    integer :: dim
+
+    if (present(must_be_present)) then
+       use_must_be_present = must_be_present
+    else
+       use_must_be_present = .true.
+    end if
+    status = nf90_inq_varid(ncid, name, varid)
+    if ((.not. use_must_be_present) .and. (status == NF90_ENOTVAR)) then
+       ! variable was not present, but that's ok
+       var = 0
+       return
+    end if
+
+    ! Find the varid
+    status = nf90_inq_varid(ncid, name, varid)
+    ! Inquire for the dimension IDs
+    call pmc_nc_check(nf90_inquire_variable(ncid, varid, dimids=dimids))
+    ! Loop over all the dimensions to get their lengths
+    do dim = 1, 4
+       call pmc_nc_check(nf90_inquire_dimension(ncid, dimids(dim), &
+            len=dim_size(dim)))
+    end do
+
+    ! Now allocate an array to hold the value
+    if (allocated(var)) deallocate(var)
+    allocate(var(dim_size(1),dim_size(2),dim_size(3),dim_size(4)))
+    call pmc_nc_check(nf90_get_var(ncid,varid,values=var))
+
+  end subroutine pmc_nc_get_4d_var_int
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Read a real 3D array from a NetCDF file.
+  subroutine pmc_nc_get_3d_var_real(ncid, var, name, must_be_present)
+
+    !> NetCDF file ID, in data mode.
+    integer, intent(in) :: ncid
+    !> Data to read.
+    real(kind=dp), allocatable, intent(out) :: var(:,:,:)
+    !> Variable name in NetCDF file.
+    character(len=*), intent(in) :: name
+    !> Whether the variable must be present in the NetCDF file
+    !> (default .true.).
+    logical, optional, intent(in) :: must_be_present
+
+    integer :: varid, status
+    logical :: use_must_be_present
+    integer :: dimids(3)
+    integer :: dim_size(3)
+    integer :: dim
+
+    if (present(must_be_present)) then
+       use_must_be_present = must_be_present
+    else
+       use_must_be_present = .true.
+    end if
+    status = nf90_inq_varid(ncid, name, varid)
+    if ((.not. use_must_be_present) .and. (status == NF90_ENOTVAR)) then
+       ! variable was not present, but that's ok
+       var = 0d0
+       return
+    end if
+
+    ! Find the varid
+    status = nf90_inq_varid(ncid, name, varid)
+    ! Inquire for the dimension IDs
+    call pmc_nc_check(nf90_inquire_variable(ncid, varid, dimids=dimids))
+    ! Loop over all the dimensions to get their lengths
+    do dim = 1, 3
+       call pmc_nc_check(nf90_inquire_dimension(ncid, dimids(dim), &
+            len=dim_size(dim)))
+    end do
+
+    ! Now allocate an array to hold the value
+    if (allocated(var)) deallocate(var)
+    allocate(var(dim_size(1),dim_size(2),dim_size(3)))
+    call pmc_nc_check(nf90_get_var(ncid,varid,values=var))
+
+  end subroutine pmc_nc_get_3d_var_real
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Read a simple real 3D array from a NetCDF file.
+  subroutine pmc_nc_read_real_3d(ncid, var, name, must_be_present)
+
+    !> NetCDF file ID, in data mode.
+    integer, intent(in) :: ncid
+    !> Data to read, must be correctly sized.
+    real(kind=dp), intent(out) :: var(:,:,:)
+    !> Variable name in NetCDF file.
+    character(len=*), intent(in) :: name
+    !> Whether the variable must be present in the NetCDF file
+    !> (default .true.).
+    logical, optional, intent(in) :: must_be_present
+
+    integer :: varid, status
+    logical :: use_must_be_present
+
+    if (present(must_be_present)) then
+       use_must_be_present = must_be_present
+    else
+       use_must_be_present = .true.
+    end if
+    status = nf90_inq_varid(ncid, name, varid)
+    if ((.not. use_must_be_present) .and. (status == NF90_ENOTVAR)) then
+       ! variable was not present, but that's ok
+       var = 0d0
+       return
+    end if
+    call pmc_nc_check_msg(status, "inquiring variable " // trim(name))
+    call pmc_nc_check_msg(nf90_get_var(ncid, varid, var), &
+         "getting variable " // trim(name))
+
+  end subroutine pmc_nc_read_real_3d
+
 end module pmc_netcdf

--- a/src/netcdf.F90
+++ b/src/netcdf.F90
@@ -73,8 +73,13 @@ contains
     !> NetCDF file ID, in data mode, returns in data mode.
     integer, intent(out) :: ncid
 
+#ifdef PMC_USE_WRF
+    call pmc_nc_check_msg(nf90_create(filename, NF90_HDF5, ncid), &
+         "opening " // trim(filename) // " for writing")
+#else
     call pmc_nc_check_msg(nf90_create(filename, NF90_CLOBBER, ncid), &
          "opening " // trim(filename) // " for writing")
+#endif
     call pmc_nc_check(nf90_enddef(ncid))
 
   end subroutine pmc_nc_open_write

--- a/src/netcdf.F90
+++ b/src/netcdf.F90
@@ -389,6 +389,159 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+  !> Read a simple real 3D array from a NetCDF file.
+  subroutine pmc_nc_read_real_3d(ncid, var, name, must_be_present)
+
+    !> NetCDF file ID, in data mode.
+    integer, intent(in) :: ncid
+    !> Data to read.
+    real(kind=dp), allocatable, intent(out) :: var(:,:,:)
+    !> Variable name in NetCDF file.
+    character(len=*), intent(in) :: name
+    !> Whether the variable must be present in the NetCDF file
+    !> (default .true.).
+    logical, optional, intent(in) :: must_be_present
+
+    integer :: varid, status
+    logical :: use_must_be_present
+    integer :: dimids(3)
+    integer :: size1, size2, size3
+
+    if (present(must_be_present)) then
+       use_must_be_present = must_be_present
+    else
+       use_must_be_present = .true.
+    end if
+    status = nf90_inq_varid(ncid, name, varid)
+    if ((.not. use_must_be_present) .and. (status == NF90_ENOTVAR)) then
+       ! variable was not present, but that's ok
+       var = reshape([real(kind=dp)::], [0, 0, 0])
+       return
+    end if
+    call pmc_nc_check_msg(status, "inquiring variable " // trim(name))
+    call pmc_nc_check_msg(nf90_inquire_variable(ncid, varid, dimids=dimids), &
+         "determining size of variable " // trim(name))
+    call pmc_nc_check_msg(nf90_inquire_dimension(ncid, dimids(1), len=size1), &
+         "determining size of dimension number " &
+         // trim(integer_to_string(dimids(1))))
+    call pmc_nc_check_msg(nf90_inquire_dimension(ncid, dimids(2), len=size2), &
+         "determining size of dimension number " &
+         // trim(integer_to_string(dimids(2))))
+    call pmc_nc_check_msg(nf90_inquire_dimension(ncid, dimids(3), len=size3), &
+         "determining size of dimension number " &
+         // trim(integer_to_string(dimids(3))))
+    call ensure_real_array_3d_size(var, size1, size2, size3)
+    call pmc_nc_check_msg(nf90_get_var(ncid, varid, var), &
+         "getting variable " // trim(name))
+
+  end subroutine pmc_nc_read_real_3d
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Read a simple real 4D array from a NetCDF file.
+  subroutine pmc_nc_read_real_4d(ncid, var, name, must_be_present)
+
+    !> NetCDF file ID, in data mode.
+    integer, intent(in) :: ncid
+    !> Data to read.
+    real(kind=dp), allocatable, intent(out) :: var(:,:,:,:)
+    !> Variable name in NetCDF file.
+    character(len=*), intent(in) :: name
+    !> Whether the variable must be present in the NetCDF file
+    !> (default .true.).
+    logical, optional, intent(in) :: must_be_present
+
+    integer :: varid, status
+    logical :: use_must_be_present
+    integer :: dimids(4)
+    integer :: size1, size2, size3, size4
+
+    if (present(must_be_present)) then
+       use_must_be_present = must_be_present
+    else
+       use_must_be_present = .true.
+    end if
+    status = nf90_inq_varid(ncid, name, varid)
+    if ((.not. use_must_be_present) .and. (status == NF90_ENOTVAR)) then
+       ! variable was not present, but that's ok
+       var = reshape([real(kind=dp)::], [0, 0, 0, 0])
+       return
+    end if
+    call pmc_nc_check_msg(status, "inquiring variable " // trim(name))
+    call pmc_nc_check_msg(nf90_inquire_variable(ncid, varid, dimids=dimids), &
+         "determining size of variable " // trim(name))
+    call pmc_nc_check_msg(nf90_inquire_dimension(ncid, dimids(1), len=size1), &
+         "determining size of dimension number " &
+         // trim(integer_to_string(dimids(1))))
+    call pmc_nc_check_msg(nf90_inquire_dimension(ncid, dimids(2), len=size2), &
+         "determining size of dimension number " &
+         // trim(integer_to_string(dimids(2))))
+    call pmc_nc_check_msg(nf90_inquire_dimension(ncid, dimids(3), len=size3), &
+         "determining size of dimension number " &
+         // trim(integer_to_string(dimids(3))))
+    call pmc_nc_check_msg(nf90_inquire_dimension(ncid, dimids(4), len=size4), &
+         "determining size of dimension number " &
+         // trim(integer_to_string(dimids(4))))
+    call ensure_real_array_4d_size(var, size1, size2, size3, size4)
+    call pmc_nc_check_msg(nf90_get_var(ncid, varid, var), &
+         "getting variable " // trim(name))
+
+  end subroutine pmc_nc_read_real_4d
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Read a simple integer 4D array from a NetCDF file.
+  subroutine pmc_nc_read_integer_4d(ncid, var, name, must_be_present)
+
+    !> NetCDF file ID, in data mode.
+    integer, intent(in) :: ncid
+    !> Data to read.
+    integer, allocatable, intent(out) :: var(:,:,:,:)
+    !> Variable name in NetCDF file.
+    character(len=*), intent(in) :: name
+    !> Whether the variable must be present in the NetCDF file
+    !> (default .true.).
+    logical, optional, intent(in) :: must_be_present
+
+    integer :: varid, status
+    logical :: use_must_be_present
+    integer :: dimids(4)
+    integer :: size1, size2, size3, size4
+
+    if (present(must_be_present)) then
+       use_must_be_present = must_be_present
+    else
+       use_must_be_present = .true.
+    end if
+    status = nf90_inq_varid(ncid, name, varid)
+    if ((.not. use_must_be_present) .and. (status == NF90_ENOTVAR)) then
+       ! variable was not present, but that's ok
+       var = reshape([integer::], [0, 0, 0, 0])
+       return
+    end if
+    call pmc_nc_check_msg(status, "inquiring variable " // trim(name))
+    call pmc_nc_check_msg(nf90_inquire_variable(ncid, varid, dimids=dimids), &
+         "determining size of variable " // trim(name))
+    call pmc_nc_check_msg(nf90_inquire_dimension(ncid, dimids(1), len=size1), &
+         "determining size of dimension number " &
+         // trim(integer_to_string(dimids(1))))
+    call pmc_nc_check_msg(nf90_inquire_dimension(ncid, dimids(2), len=size2), &
+         "determining size of dimension number " &
+         // trim(integer_to_string(dimids(2))))
+    call pmc_nc_check_msg(nf90_inquire_dimension(ncid, dimids(3), len=size3), &
+         "determining size of dimension number " &
+         // trim(integer_to_string(dimids(3))))
+    call pmc_nc_check_msg(nf90_inquire_dimension(ncid, dimids(4), len=size4), &
+         "determining size of dimension number " &
+         // trim(integer_to_string(dimids(4))))
+    call ensure_integer_array_4d_size(var, size1, size2, size3, size4)
+    call pmc_nc_check_msg(nf90_get_var(ncid, varid, var), &
+         "getting variable " // trim(name))
+
+  end subroutine pmc_nc_read_integer_4d
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
   !> Write attributes for a variable to a NetCDF file.
   subroutine pmc_nc_write_atts(ncid, varid, unit, long_name, standard_name, &
        description)
@@ -738,191 +891,6 @@ contains
          start = start, count = count))
 
   end subroutine pmc_nc_write_integer_2d
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-  !> Read a real 4D array from a NetCDF file.
-  subroutine pmc_nc_get_4d_var_real(ncid, var, name, must_be_present)
-
-    !> NetCDF file ID, in data mode.
-    integer, intent(in) :: ncid
-    !> Data to read.
-    real(kind=dp), allocatable, intent(out) :: var(:,:,:,:)
-    !> Variable name in NetCDF file.
-    character(len=*), intent(in) :: name
-    !> Whether the variable must be present in the NetCDF file
-    !> (default .true.).
-    logical, optional, intent(in) :: must_be_present
-
-    integer :: varid, status
-    logical :: use_must_be_present
-    integer :: dimids(4)
-    integer :: dim_size(4)
-    integer :: dim
-
-    if (present(must_be_present)) then
-       use_must_be_present = must_be_present
-    else
-       use_must_be_present = .true.
-    end if
-    status = nf90_inq_varid(ncid, name, varid)
-    if ((.not. use_must_be_present) .and. (status == NF90_ENOTVAR)) then
-       ! variable was not present, but that's ok
-       var = 0d0
-       return
-    end if
-
-    ! Find the varid
-    status = nf90_inq_varid(ncid, name, varid)
-    ! Inquire for the dimension IDs
-    call pmc_nc_check(nf90_inquire_variable(ncid, varid, dimids=dimids))
-    ! Loop over all the dimensions to get their lengths
-    do dim = 1,4
-       call pmc_nc_check(nf90_inquire_dimension(ncid, dimids(dim), &
-            len=dim_size(dim)))
-    end do
-
-    ! Now allocate an array to hold the value
-    if (allocated(var)) deallocate(var)
-    allocate(var(dim_size(1), dim_size(2), dim_size(3), dim_size(4)))
-    call pmc_nc_check(nf90_get_var(ncid, varid, values=var))
-
-  end subroutine pmc_nc_get_4d_var_real
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-  !> Read a integer 4D array from a NetCDF file.
-  subroutine pmc_nc_get_4d_var_int(ncid, var, name, must_be_present)
-
-    !> NetCDF file ID, in data mode.
-    integer, intent(in) :: ncid
-    !> Data to read.
-    integer, allocatable, intent(out) :: var(:,:,:,:)
-    !> Variable name in NetCDF file.
-    character(len=*), intent(in) :: name
-    !> Whether the variable must be present in the NetCDF file
-    !> (default .true.).
-    logical, optional, intent(in) :: must_be_present
-
-    integer :: varid, status
-    logical :: use_must_be_present
-    integer :: dimids(4)
-    integer :: dim_size(4)
-    integer :: dim
-
-    if (present(must_be_present)) then
-       use_must_be_present = must_be_present
-    else
-       use_must_be_present = .true.
-    end if
-    status = nf90_inq_varid(ncid, name, varid)
-    if ((.not. use_must_be_present) .and. (status == NF90_ENOTVAR)) then
-       ! variable was not present, but that's ok
-       var = 0
-       return
-    end if
-
-    ! Find the varid
-    status = nf90_inq_varid(ncid, name, varid)
-    ! Inquire for the dimension IDs
-    call pmc_nc_check(nf90_inquire_variable(ncid, varid, dimids=dimids))
-    ! Loop over all the dimensions to get their lengths
-    do dim = 1,4
-       call pmc_nc_check(nf90_inquire_dimension(ncid, dimids(dim), &
-            len=dim_size(dim)))
-    end do
-
-    ! Now allocate an array to hold the value
-    if (allocated(var)) deallocate(var)
-    allocate(var(dim_size(1), dim_size(2), dim_size(3), dim_size(4)))
-    call pmc_nc_check(nf90_get_var(ncid, varid, values=var))
-
-  end subroutine pmc_nc_get_4d_var_int
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-  !> Read a real 3D array from a NetCDF file.
-  subroutine pmc_nc_get_3d_var_real(ncid, var, name, must_be_present)
-
-    !> NetCDF file ID, in data mode.
-    integer, intent(in) :: ncid
-    !> Data to read.
-    real(kind=dp), allocatable, intent(out) :: var(:,:,:)
-    !> Variable name in NetCDF file.
-    character(len=*), intent(in) :: name
-    !> Whether the variable must be present in the NetCDF file
-    !> (default .true.).
-    logical, optional, intent(in) :: must_be_present
-
-    integer :: varid, status
-    logical :: use_must_be_present
-    integer :: dimids(3)
-    integer :: dim_size(3)
-    integer :: dim
-
-    if (present(must_be_present)) then
-       use_must_be_present = must_be_present
-    else
-       use_must_be_present = .true.
-    end if
-    status = nf90_inq_varid(ncid, name, varid)
-    if ((.not. use_must_be_present) .and. (status == NF90_ENOTVAR)) then
-       ! variable was not present, but that's ok
-       var = 0d0
-       return
-    end if
-
-    ! Find the varid
-    status = nf90_inq_varid(ncid, name, varid)
-    ! Inquire for the dimension IDs
-    call pmc_nc_check(nf90_inquire_variable(ncid, varid, dimids=dimids))
-    ! Loop over all the dimensions to get their lengths
-    do dim = 1,3
-       call pmc_nc_check(nf90_inquire_dimension(ncid, dimids(dim), &
-            len=dim_size(dim)))
-    end do
-
-    ! Now allocate an array to hold the value
-    if (allocated(var)) deallocate(var)
-    allocate(var(dim_size(1), dim_size(2), dim_size(3)))
-    call pmc_nc_check(nf90_get_var(ncid, varid, values=var))
-
-  end subroutine pmc_nc_get_3d_var_real
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-  !> Read a simple real 3D array from a NetCDF file.
-  subroutine pmc_nc_read_real_3d(ncid, var, name, must_be_present)
-
-    !> NetCDF file ID, in data mode.
-    integer, intent(in) :: ncid
-    !> Data to read, must be correctly sized.
-    real(kind=dp), intent(out) :: var(:,:,:)
-    !> Variable name in NetCDF file.
-    character(len=*), intent(in) :: name
-    !> Whether the variable must be present in the NetCDF file
-    !> (default .true.).
-    logical, optional, intent(in) :: must_be_present
-
-    integer :: varid, status
-    logical :: use_must_be_present
-
-    if (present(must_be_present)) then
-       use_must_be_present = must_be_present
-    else
-       use_must_be_present = .true.
-    end if
-    status = nf90_inq_varid(ncid, name, varid)
-    if ((.not. use_must_be_present) .and. (status == NF90_ENOTVAR)) then
-       ! variable was not present, but that's ok
-       var = 0d0
-       return
-    end if
-    call pmc_nc_check_msg(status, "inquiring variable " // trim(name))
-    call pmc_nc_check_msg(nf90_get_var(ncid, varid, var), &
-         "getting variable " // trim(name))
-
-  end subroutine pmc_nc_read_real_3d
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/netcdf.F90
+++ b/src/netcdf.F90
@@ -777,15 +777,15 @@ contains
     ! Inquire for the dimension IDs
     call pmc_nc_check(nf90_inquire_variable(ncid, varid, dimids=dimids))
     ! Loop over all the dimensions to get their lengths
-    do dim = 1, 4
+    do dim = 1,4
        call pmc_nc_check(nf90_inquire_dimension(ncid, dimids(dim), &
             len=dim_size(dim)))
     end do
 
     ! Now allocate an array to hold the value
     if (allocated(var)) deallocate(var)
-    allocate(var(dim_size(1),dim_size(2),dim_size(3),dim_size(4)))
-    call pmc_nc_check(nf90_get_var(ncid,varid,values=var))
+    allocate(var(dim_size(1), dim_size(2), dim_size(3), dim_size(4)))
+    call pmc_nc_check(nf90_get_var(ncid, varid, values=var))
 
   end subroutine pmc_nc_get_4d_var_real
 
@@ -827,15 +827,15 @@ contains
     ! Inquire for the dimension IDs
     call pmc_nc_check(nf90_inquire_variable(ncid, varid, dimids=dimids))
     ! Loop over all the dimensions to get their lengths
-    do dim = 1, 4
+    do dim = 1,4
        call pmc_nc_check(nf90_inquire_dimension(ncid, dimids(dim), &
             len=dim_size(dim)))
     end do
 
     ! Now allocate an array to hold the value
     if (allocated(var)) deallocate(var)
-    allocate(var(dim_size(1),dim_size(2),dim_size(3),dim_size(4)))
-    call pmc_nc_check(nf90_get_var(ncid,varid,values=var))
+    allocate(var(dim_size(1), dim_size(2), dim_size(3), dim_size(4)))
+    call pmc_nc_check(nf90_get_var(ncid, varid, values=var))
 
   end subroutine pmc_nc_get_4d_var_int
 
@@ -877,15 +877,15 @@ contains
     ! Inquire for the dimension IDs
     call pmc_nc_check(nf90_inquire_variable(ncid, varid, dimids=dimids))
     ! Loop over all the dimensions to get their lengths
-    do dim = 1, 3
+    do dim = 1,3
        call pmc_nc_check(nf90_inquire_dimension(ncid, dimids(dim), &
             len=dim_size(dim)))
     end do
 
     ! Now allocate an array to hold the value
     if (allocated(var)) deallocate(var)
-    allocate(var(dim_size(1),dim_size(2),dim_size(3)))
-    call pmc_nc_check(nf90_get_var(ncid,varid,values=var))
+    allocate(var(dim_size(1), dim_size(2), dim_size(3)))
+    call pmc_nc_check(nf90_get_var(ncid, varid, values=var))
 
   end subroutine pmc_nc_get_3d_var_real
 
@@ -923,5 +923,7 @@ contains
          "getting variable " // trim(name))
 
   end subroutine pmc_nc_read_real_3d
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 end module pmc_netcdf

--- a/src/output.F90
+++ b/src/output.F90
@@ -360,8 +360,13 @@ contains
     !!     involved in writing data (may be less than the total number of
     !!     processes that computed the data)
 
+#ifdef PMC_USE_WRF
+    write(filename,'(a,a,i3.3,a,i3.3,a,i3.3,a,i8.8,a)') trim(prefix), &
+         '_',env_state%ix,'_',env_state%iy,'_',env_state%iz,'_', index,'.nc'
+#else
     call make_filename(filename, prefix, ".nc", index, i_repeat, write_rank, &
          write_n_proc)
+#endif
     call pmc_nc_open_write(filename, ncid)
     call pmc_nc_write_info(ncid, uuid, &
          "PartMC version " // trim(PARTMC_VERSION), write_rank, write_n_proc)

--- a/src/output.F90
+++ b/src/output.F90
@@ -871,6 +871,7 @@ contains
     integer :: ncid_group
     integer :: k
 
+#ifdef PMC_USE_WRF
     write(filename,'(a,a,i3.3,a,i3.3,a,i8.8,a)') trim(prefix), &
          '_', env_state(1)%ix, '_', env_state(1)%iy, '_', index, '.nc'
     call pmc_nc_open_write(filename, ncid)
@@ -894,6 +895,7 @@ contains
     end do
 
     call pmc_nc_check(nf90_close(ncid))
+#endif
 
   end subroutine output_column_to_file
 

--- a/src/output.F90
+++ b/src/output.F90
@@ -312,11 +312,6 @@ contains
 
     character(len=len(prefix)+100) :: filename
     integer :: ncid
-#ifdef PMC_USE_WRF
-    character(len=50) :: group_name
-    integer :: ncid_group
-    integer :: k
-#endif
 
     !> \page output_format_general Output File Format: General Information
     !!

--- a/src/scenario.F90
+++ b/src/scenario.F90
@@ -230,7 +230,7 @@ contains
     call gas_state_mole_dens_to_ppb(emissions, env_state)
     p = emission_rate_scale * delta_t / env_state%height
     call gas_state_add_scaled(gas_state, emissions, p)
-
+#ifndef PMC_USE_WRF
     ! dilution
     call gas_state_interp_1d(scenario%gas_background, &
          scenario%gas_dilution_time, scenario%gas_dilution_rate, &
@@ -241,6 +241,7 @@ contains
     end if
     call gas_state_scale(gas_state, p)
     call gas_state_add_scaled(gas_state, background, 1d0 - p)
+#endif
     call gas_state_ensure_nonnegative(gas_state)
 
   end subroutine scenario_update_gas_state
@@ -292,7 +293,7 @@ contains
     call aero_state_add_aero_dist_sample(aero_state, aero_data, &
          emissions, p, env_state%elapsed_time, allow_doubling, allow_halving, &
          n_emit)
-
+#ifndef PMC_USE_WRF
     ! dilution
     call aero_dist_interp_1d(scenario%aero_background, &
          scenario%aero_dilution_time, scenario%aero_dilution_rate, &
@@ -313,7 +314,8 @@ contains
     ! particle loss function
     call scenario_particle_loss(scenario, delta_t, aero_data, aero_state, &
          env_state)
-    
+#endif
+
     ! update computational volume
     call aero_weight_array_scale(aero_state%awa, &
          old_env_state%temp * env_state%pressure &

--- a/src/util.F90
+++ b/src/util.F90
@@ -1111,6 +1111,104 @@ contains
 
   !> Allocate or reallocate the given array to ensure it is of the
   !> given size, preserving any data and/or initializing to 0.
+  subroutine ensure_real_array_3d_size(x, n1, n2, n3, only_grow)
+
+    !> Array of real numbers.
+    real(kind=dp), intent(inout), allocatable :: x(:, :, :)
+    !> Desired first size of array.
+    integer, intent(in) :: n1
+    !> Desired second size of array.
+    integer, intent(in) :: n2
+    !> Desired third size of array.
+    integer, intent(in) :: n3
+    !> Whether to only increase the array size (default .true.).
+    logical, intent(in), optional :: only_grow
+
+    integer :: new_n1, new_n2, new_n3, n1_min, n2_min, n3_min
+    real(kind=dp), allocatable :: tmp_x(:, :, :)
+
+    if (allocated(x)) then
+       new_n1 = n1
+       new_n2 = n2
+       new_n3 = n3
+       if (present(only_grow)) then
+          new_n1 = max(new_n1, size(x, 1))
+          new_n2 = max(new_n2, size(x, 2))
+          new_n3 = max(new_n3, size(x, 3))
+       end if
+       if ((size(x, 1) /= new_n1) .or. (size(x, 2) /= new_n2) &
+            .or. (size(x,3) /= new_n3)) then
+          allocate(tmp_x(new_n1, new_n2, new_n3))
+          n1_min = min(new_n1, size(x, 1))
+          n2_min = min(new_n2, size(x, 2))
+          n3_min = min(new_n3, size(x, 3))
+          tmp_x = 0d0
+          tmp_x(1:n1_min, 1:n2_min, 1:n3_min) = x(1:n1_min, 1:n2_min, 1:n3_min)
+          call move_alloc(tmp_x, x)
+       end if
+    else
+       allocate(x(n1, n2, n3))
+       x = 0d0
+    end if
+
+  end subroutine ensure_real_array_3d_size
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Allocate or reallocate the given array to ensure it is of the
+  !> given size, preserving any data and/or initializing to 0.
+  subroutine ensure_real_array_4d_size(x, n1, n2, n3, n4, only_grow)
+
+    !> Array of real numbers.
+    real(kind=dp), intent(inout), allocatable :: x(:, :, :, :)
+    !> Desired first size of array.
+    integer, intent(in) :: n1
+    !> Desired second size of array.
+    integer, intent(in) :: n2
+    !> Desired third size of array.
+    integer, intent(in) :: n3
+    !> Desired fourth size of array.
+    integer, intent(in) :: n4
+    !> Whether to only increase the array size (default .true.).
+    logical, intent(in), optional :: only_grow
+
+    integer :: new_n1, new_n2, new_n3, new_n4, n1_min, n2_min, n3_min, n4_min
+    real(kind=dp), allocatable :: tmp_x(:, :, :, :)
+
+    if (allocated(x)) then
+       new_n1 = n1
+       new_n2 = n2
+       new_n3 = n3
+       new_n4 = n4
+       if (present(only_grow)) then
+          new_n1 = max(new_n1, size(x, 1))
+          new_n2 = max(new_n2, size(x, 2))
+          new_n3 = max(new_n3, size(x, 3))
+          new_n4 = max(new_n4, size(x, 4))
+       end if
+       if ((size(x, 1) /= new_n1) .or. (size(x, 2) /= new_n2) &
+            .or. (size(x, 3) /= new_n3) .or. (size(x, 4) /= new_n4)) then
+          allocate(tmp_x(new_n1, new_n2, new_n3, new_n4))
+          n1_min = min(new_n1, size(x, 1))
+          n2_min = min(new_n2, size(x, 2))
+          n3_min = min(new_n3, size(x, 3))
+          n4_min = min(new_n4, size(x, 4))
+          tmp_x = 0d0
+          tmp_x(1:n1_min, 1:n2_min, 1:n3_min, 1:n4_min) = x(1:n1_min, &
+               1:n2_min, 1:n3_min, 1:n4_min)
+          call move_alloc(tmp_x, x)
+       end if
+    else
+       allocate(x(n1, n2, n3, n4))
+       x = 0d0
+    end if
+
+  end subroutine ensure_real_array_4d_size
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Allocate or reallocate the given array to ensure it is of the
+  !> given size, preserving any data and/or initializing to 0.
   subroutine ensure_integer_array_size(x, n, only_grow)
 
     !> Array of integer numbers.
@@ -1180,6 +1278,104 @@ contains
     end if
 
   end subroutine ensure_integer_array_2d_size
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Allocate or reallocate the given array to ensure it is of the
+  !> given size, preserving any data and/or initializing to 0.
+  subroutine ensure_integer_array_3d_size(x, n1, n2, n3, only_grow)
+
+    !> Array of integer numbers.
+    integer, intent(inout), allocatable :: x(:, :, :)
+    !> Desired first size of array.
+    integer, intent(in) :: n1
+    !> Desired second size of array.
+    integer, intent(in) :: n2
+    !> Desired third size of array.
+    integer, intent(in) :: n3
+    !> Whether to only increase the array size (default .true.).
+    logical, intent(in), optional :: only_grow
+
+    integer :: new_n1, new_n2, new_n3, n1_min, n2_min, n3_min
+    integer, allocatable :: tmp_x(:, :, :)
+
+    if (allocated(x)) then
+       new_n1 = n1
+       new_n2 = n2
+       new_n3 = n3
+       if (present(only_grow)) then
+          new_n1 = max(new_n1, size(x, 1))
+          new_n2 = max(new_n2, size(x, 2))
+          new_n3 = max(new_n2, size(x, 3))
+       end if
+       if ((size(x, 1) /= new_n1) .or. (size(x, 2) /= new_n2) &
+            .or. (size(x,3) /= new_n3)) then
+          allocate(tmp_x(new_n1, new_n2, new_n3))
+          n1_min = min(new_n1, size(x, 1))
+          n2_min = min(new_n2, size(x, 2))
+          n3_min = min(new_n3, size(x, 3))
+          tmp_x = 0
+          tmp_x(1:n1_min, 1:n2_min, 1:n3_min) = x(1:n1_min, 1:n2_min, 1:n3_min)
+          call move_alloc(tmp_x, x)
+       end if
+    else
+       allocate(x(n1, n2, n3))
+       x = 0
+    end if
+
+  end subroutine ensure_integer_array_3d_size
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Allocate or reallocate the given array to ensure it is of the
+  !> given size, preserving any data and/or initializing to 0.
+  subroutine ensure_integer_array_4d_size(x, n1, n2, n3, n4, only_grow)
+
+    !> Array of integer numbers.
+    integer, intent(inout), allocatable :: x(:, :, :, :)
+    !> Desired first size of array.
+    integer, intent(in) :: n1
+    !> Desired second size of array.
+    integer, intent(in) :: n2
+    !> Desired third size of array.
+    integer, intent(in) :: n3
+    !> Desired fourth size of array.
+    integer, intent(in) :: n4
+    !> Whether to only increase the array size (default .true.).
+    logical, intent(in), optional :: only_grow
+
+    integer :: new_n1, new_n2, new_n3, new_n4, n1_min, n2_min, n3_min, n4_min
+    integer, allocatable :: tmp_x(:, :, :, :)
+
+    if (allocated(x)) then
+       new_n1 = n1
+       new_n2 = n2
+       new_n3 = n3
+       new_n4 = n4
+       if (present(only_grow)) then
+          new_n1 = max(new_n1, size(x, 1))
+          new_n2 = max(new_n2, size(x, 2))
+          new_n3 = max(new_n3, size(x, 3))
+          new_n4 = max(new_n4, size(x, 4))
+       end if
+       if ((size(x, 1) /= new_n1) .or. (size(x, 2) /= new_n2) &
+            .or. (size(x, 3) /= new_n3) .or. (size(x, 4) /= new_n4)) then
+          allocate(tmp_x(new_n1, new_n2, new_n3, new_n4))
+          n1_min = min(new_n1, size(x, 1))
+          n2_min = min(new_n2, size(x, 2))
+          n3_min = min(new_n3, size(x, 3))
+          n4_min = min(new_n4, size(x, 4))
+          tmp_x = 0
+          tmp_x(1:n1_min, 1:n2_min, 1:n3_min, 1:n4_min) = x(1:n1_min, &
+               1:n2_min, 1:n3_min, 1:n4_min)
+          call move_alloc(tmp_x, x)
+       end if
+    else
+       allocate(x(n1, n2, n3, n4))
+       x = 0
+    end if
+
+  end subroutine ensure_integer_array_4d_size
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 


### PR DESCRIPTION
This is to merge in WRF-PartMC features into PartMC. This includes:

- Added CPP for code specific for WRF-PartMC. Requires `-DPMC_USE_WRF`.
- New NetCDF subroutines for reading 3D and 4D arrays. Added subroutines to ensure proper array size.
- New MPI pack/unpack/pack_size code for handling 3D/5D arrays.
- Makefile for compiling PartMC in WRF build system.