### PR TITLE
set the next particle id for restart based on input aero_state

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@ __next version__ - XXXX-XX-XX
 
   * Clean up README formatting (Matt West).
 
+  * Fix particle ID initialization after loading of `aero_state`
+    (Jeff Curtis).
+
 2.5.0 - 2018-11-17
 
   * Shift NetCDF CMake rules to `netcdf.cmake` (Matt West).

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -2832,6 +2832,8 @@ contains
        call aero_state_add_particle(aero_state, aero_particle, aero_data)
     end do
 
+    next_id = maxval(aero_id) + 1
+
     call pmc_nc_read_integer_1d(ncid, aero_removed_id, &
          "aero_removed_id", must_be_present=.false.)
     call pmc_nc_read_integer_1d(ncid, aero_removed_action, &


### PR DESCRIPTION
Fixes #67 by setting the next particle ID properly.