### PR TITLE
Making external mixtures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,13 @@ add_executable(bin_average_comp src/bin_average_comp.F90)
 target_link_libraries(bin_average_comp partmclib)
 
 ######################################################################
+# bin_deaverage_comp
+
+add_executable(bin_deaverage_comp src/bin_deaverage_comp.F90)
+
+target_link_libraries(bin_deaverage_comp partmclib)
+
+######################################################################
 # bin_average_size
 
 add_executable(bin_average_size src/bin_average_size.F90)

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -1963,6 +1963,7 @@ contains
     integer, allocatable :: shuffle_particles(:)
     integer :: species_group_numbers(aero_data_n_spec(aero_data))
     integer :: n_group, i_group, i_name, next_group_number
+    real(kind=dp), allocatable :: group_masses(:)
 
     call aero_state_sort(aero_state, aero_data, bin_grid)
 
@@ -1971,8 +1972,8 @@ contains
        ! species_group_numbers(i_spec) will give the group number for
        ! each species
        species_group_numbers = 0
-       do i_group = 1, n_group
-          do i_name = 1, size(groups, 2)
+       do i_group = 1,n_group
+          do i_name = 1,size(groups, 2)
              if (len_trim(groups(i_group, i_name)) > 0) then
                 i_spec = aero_data_spec_by_name(aero_data, &
                      groups(i_group, i_name))
@@ -1993,6 +1994,9 @@ contains
     end if
 
     do i_bin = 1,bin_grid_size(bin_grid)
+!       if (present(groups)) then
+!
+!       else
        species_volume_conc = 0d0
        total_volume_conc = 0d0
        do i_class = 1,size(aero_state%awa%weight, 2)
@@ -2019,8 +2023,10 @@ contains
           particle_fractions = n_parts * species_volume_conc / total_volume_conc
           print*, particle_fractions
           print*, 'total particles', n_parts
-
-          shuffle_particles=[(i,i=1,n_parts)]
+          allocate(shuffle_particles(n_parts))
+          do i_part = 1,n_parts
+              shuffle_particles(i_part) = i_part 
+          end do
           call shuffle_array(shuffle_particles, n_parts)
           start_val = 1
           edge_case = .false.
@@ -2047,6 +2053,7 @@ contains
                  start_val = start_val + n_part_spec
              end if
           end do
+          deallocate(shuffle_particles)
        end do
     end do
 

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -1968,6 +1968,7 @@ contains
     integer :: n_group, i_group, i_name
     real(kind=dp), allocatable :: group_fractions(:), &
         group_volume_conc(:)
+    ! Flag to control algorithm selection - false uses low-variance method.
     logical, parameter :: do_naive_algorithm = .false.
     real(kind=dp), allocatable :: cumulative_vals(:)
     real(kind=dp), allocatable :: factors_2d(:,:)

--- a/src/aero_state.F90
+++ b/src/aero_state.F90
@@ -1993,8 +1993,6 @@ contains
           end if
        end do
        print*, species_group_numbers
-       allocate(group_fractions(n_group))
-       allocate(group_volume_conc(n_group))
     end if
 
     do i_bin = 1,bin_grid_size(bin_grid)
@@ -2020,13 +2018,15 @@ contains
           ! Get the total particles
           n_parts = integer_varray_n_entry( &
                aero_state%aero_sorted%size_class%inverse(i_bin, i_class))
-          group_volume_conc = 0.0d0
           if (present(groups)) then
+             allocate(group_volume_conc(n_group))
+             group_volume_conc = 0.0d0
              do i_spec = 1,aero_data_n_spec(aero_data)
                 group_volume_conc(species_group_numbers(i_spec)) &
                    =  group_volume_conc(species_group_numbers(i_spec)) &
                    + species_volume_conc(i_spec)
              end do
+             allocate(group_fractions(n_group))
              group_fractions = 0.0d0
              do i_group = 1,n_group
                 group_fractions(i_group) = n_parts * group_volume_conc(i_group) / total_volume_conc
@@ -2074,6 +2074,8 @@ contains
                 end if
              end do
              deallocate(shuffle_particles)
+             deallocate(group_fractions)
+             deallocate(group_volume_conc)
           else
           particle_fractions = n_parts * species_volume_conc / total_volume_conc
           print*, particle_fractions

--- a/src/bin_average_comp.F90
+++ b/src/bin_average_comp.F90
@@ -66,6 +66,8 @@ program bin_average_comp
 
   call pmc_mpi_init()
 
+  call pmc_srand(0, pmc_mpi_rank())
+
   call bin_grid_make(bin_grid, BIN_GRID_TYPE_LOG, n_bin, diam2rad(d_min), &
        diam2rad(d_max))
 

--- a/src/bin_deaverage_comp.F90
+++ b/src/bin_deaverage_comp.F90
@@ -1,0 +1,90 @@
+! Copyright (C) 2009-2013 Matthew West
+! Licensed under the GNU General Public License version 2 or (at your
+! option) any later version. See the file COPYING for details.
+
+!> \file
+!> The bin_average_comp program.
+
+!> Read a NetCDF file, average the composition of all particles within
+!> each bin, and write the data out as another NetCDF file.
+program bin_deaverage_comp
+
+  use pmc_aero_state
+  use pmc_gas_data
+  use pmc_gas_state
+  use pmc_env_state
+  use pmc_aero_data
+  use pmc_bin_grid
+  use pmc_output
+  use pmc_rand
+  use netcdf
+
+  character(len=1000) :: in_filename, out_prefix
+  type(bin_grid_t) :: bin_grid
+  type(aero_data_t) :: aero_data
+  type(aero_state_t) :: aero_state
+  type(gas_data_t) :: gas_data
+  type(gas_state_t) :: gas_state
+  type(env_state_t) :: env_state
+  integer :: n_bin, index, i_repeat, output_type
+  real(kind=dp) :: d_min, d_max, time, del_t
+  character(len=1000) :: tmp_str
+  logical :: record_removals, dry_volume, record_optical
+  character(len=PMC_UUID_LEN) :: uuid
+
+  ! process commandline arguments
+  if (command_argument_count() .ne. 6) then
+     write(6,*) 'Usage: bin_average_comp <d_min> <d_max> <n_bin> ' &
+          // '<"wet" or "dry"> <input_filename> <output_prefix>'
+     write(6,*) ''
+     write(6,*) '  d_min: minimum bin diameter (m)'
+     write(6,*) '  d_max: maximum bin diameter (m)'
+     write(6,*) '  n_bin: number of bins'
+     write(6,*) '  wet/dry: average wet or dry sizes'
+     write(6,*) '  input_filename: like scenario_0001_00000001.nc'
+     write(6,*) '  output_prefix: like scenario_comp_average'
+     stop 2
+  endif
+  call get_command_argument(1, tmp_str)
+  d_min = string_to_real(tmp_str)
+  call get_command_argument(2, tmp_str)
+  d_max = string_to_real(tmp_str)
+  call get_command_argument(3, tmp_str)
+  n_bin = string_to_integer(tmp_str)
+  call get_command_argument(4, tmp_str)
+  if (trim(tmp_str) == "wet") then
+     dry_volume = .false.
+  elseif (trim(tmp_str) == "dry") then
+     dry_volume = .true.
+  else
+     write(6,*) 'Argument 4 must be "wet" or "dry", not ' &
+          // trim(tmp_str)
+     stop 1
+  end if
+  call get_command_argument(5, in_filename)
+  call get_command_argument(6, out_prefix)
+
+  call pmc_mpi_init()
+
+  call bin_grid_make(bin_grid, BIN_GRID_TYPE_LOG, n_bin, diam2rad(d_min), &
+       diam2rad(d_max))
+
+  call input_state(in_filename, index, time, del_t, i_repeat, uuid, &
+       aero_data, aero_state, gas_data, gas_state, env_state)
+
+  if (dry_volume) then
+     call aero_state_make_dry(aero_state, aero_data)
+  end if
+
+  call aero_state_bin_deaverage_comp(aero_state, bin_grid, aero_data)
+
+  output_type = OUTPUT_TYPE_SINGLE
+  record_removals = .false.
+  record_optical = .true.
+  call output_state(out_prefix, output_type, aero_data, aero_state, &
+       gas_data, gas_state, env_state, index, time, del_t, i_repeat, &
+       record_removals, record_optical, uuid)
+
+  call pmc_mpi_finalize()
+
+end program bin_deaverage_comp

--- a/src/bin_deaverage_comp.F90
+++ b/src/bin_deaverage_comp.F90
@@ -31,6 +31,12 @@ program bin_deaverage_comp
   character(len=1000) :: tmp_str
   logical :: record_removals, dry_volume, record_optical
   character(len=PMC_UUID_LEN) :: uuid
+  character(len=AERO_NAME_LEN), allocatable :: external_groups(:,:)
+
+  allocate(external_groups(3, 4)) ! 3 groups, max 4 species per group
+  external_groups(1,:) = ["OC    ", "BC    ", "      ", "      "]
+  external_groups(2,:) = ["API1  ", "API2  ", "LIM1  ", "LIM2  "]
+  external_groups(3,:) = ["SO4   ", "NO3   ", "NH4   ", "      "]
 
   ! process commandline arguments
   if (command_argument_count() .ne. 6) then
@@ -76,7 +82,8 @@ program bin_deaverage_comp
      call aero_state_make_dry(aero_state, aero_data)
   end if
 
-  call aero_state_bin_deaverage_comp(aero_state, bin_grid, aero_data)
+  call aero_state_bin_deaverage_comp(aero_state, bin_grid, aero_data, &
+       external_groups)
 
   output_type = OUTPUT_TYPE_SINGLE
   record_removals = .false.

--- a/src/bin_deaverage_comp.F90
+++ b/src/bin_deaverage_comp.F90
@@ -72,6 +72,8 @@ program bin_deaverage_comp
 
   call pmc_mpi_init()
 
+  call pmc_srand(0, pmc_mpi_rank())
+
   call bin_grid_make(bin_grid, BIN_GRID_TYPE_LOG, n_bin, diam2rad(d_min), &
        diam2rad(d_max))
 

--- a/src/rand.F90
+++ b/src/rand.F90
@@ -208,6 +208,29 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+  !> Shuffles randomly an array of integer values.
+  subroutine pmc_rand_shuffle_array(array, n_values)
+    !> Array of values.
+    integer, intent(inout) :: array(n_values)
+    !> Number of values.
+    integer, intent(in) :: n_values
+
+    integer :: temp
+    integer :: i, j
+    real(kind=dp) :: u
+
+    do i=1,n_values-1
+         u = pmc_random()
+         j = i + floor((n_values-i+1)*u)
+         temp=array(j)
+         array(j)=array(i)
+         array(i)=temp
+    end do
+
+  end subroutine pmc_rand_shuffle_array
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
   !> Round val to \c floor(val) or \c ceiling(val) with probability
   !> proportional to the relative distance from \c val. That is,
   !> Prob(prob_round(val) == floor(val)) = ceil(val) - val.

--- a/src/rand.F90
+++ b/src/rand.F90
@@ -241,8 +241,6 @@ contains
     array_c = int(array, kind=c_int)
     call rand_check_gsl(388234845, pmc_rand_shuffle_gsl(array_c, n_c))
     array = int(array_c)
-    print*, 'in fortran after call'
-    print*, array
 #else
     do i=1,n_values-1
          u = pmc_random()

--- a/src/rand.F90
+++ b/src/rand.F90
@@ -219,6 +219,31 @@ contains
     integer :: i, j
     real(kind=dp) :: u
 
+#ifdef PMC_USE_GSL
+    integer(kind=c_int) :: n_c
+    integer(kind=c_int) :: array_c(n_values)
+#endif
+
+#ifdef PMC_USE_GSL
+#ifndef DOXYGEN_SKIP_DOC
+    interface
+       integer(kind=c_int) function pmc_rand_shuffle_gsl(array, n) bind(c)
+         use iso_c_binding
+         integer(kind=c_int), value :: n
+         integer(kind=c_int) :: array(n)
+       end function pmc_rand_shuffle_gsl
+    end interface
+#endif
+#endif
+
+#ifdef PMC_USE_GSL
+    n_c = int(n_values, kind=c_int)
+    array_c = int(array, kind=c_int)
+    call rand_check_gsl(388234845, pmc_rand_shuffle_gsl(array_c, n_c))
+    array = int(array_c)
+    print*, 'in fortran after call'
+    print*, array
+#else
     do i=1,n_values-1
          u = pmc_random()
          j = i + floor((n_values-i+1)*u)
@@ -226,6 +251,7 @@ contains
          array(j)=array(i)
          array(i)=temp
     end do
+#endif
 
   end subroutine pmc_rand_shuffle_array
 

--- a/src/rand_gsl.c
+++ b/src/rand_gsl.c
@@ -150,3 +150,22 @@ int pmc_rand_binomial_gsl(int n, double p, int *harvest)
         *harvest = gsl_ran_binomial(pmc_rand_gsl_rng, p, u);
         return PMC_RAND_GSL_SUCCESS;
 }
+
+int pmc_rand_shuffle_gsl(int *array, int n)
+{
+        printf("array size %u \n", n);
+        for (int i = 0 ; i < n ; i++)
+        {
+            printf("%u\n", array[i]);
+        }
+        if (!pmc_rand_gsl_rng) {
+                return PMC_RAND_GSL_NOT_INIT;
+        }
+        gsl_ran_shuffle(pmc_rand_gsl_rng, array, n, sizeof (int));
+        for (int i = 0 ; i < n ; i++)
+        {
+            printf("%u\n", array[i]);
+        }
+
+        return PMC_RAND_GSL_SUCCESS;
+}

--- a/src/rand_gsl.c
+++ b/src/rand_gsl.c
@@ -153,19 +153,9 @@ int pmc_rand_binomial_gsl(int n, double p, int *harvest)
 
 int pmc_rand_shuffle_gsl(int *array, int n)
 {
-        printf("array size %u \n", n);
-        for (int i = 0 ; i < n ; i++)
-        {
-            printf("%u\n", array[i]);
-        }
         if (!pmc_rand_gsl_rng) {
                 return PMC_RAND_GSL_NOT_INIT;
         }
         gsl_ran_shuffle(pmc_rand_gsl_rng, array, n, sizeof (int));
-        for (int i = 0 ; i < n ; i++)
-        {
-            printf("%u\n", array[i]);
-        }
-
         return PMC_RAND_GSL_SUCCESS;
 }


### PR DESCRIPTION
Add the ability to "de-average" the particle-resolved population to unmix aerosol species. If no species groups are specified, the "de-averaged" population will represent a fully externally mixed population.