### PR TITLE
Change timestepping structure in run_part

### DIFF
--- a/src/run_part.F90
+++ b/src/run_part.F90
@@ -164,6 +164,10 @@ contains
     type(camp_env_state_t) :: camp_env_state
 #endif
 
+    logical, parameter :: option_1 = .false.
+    logical, parameter :: option_2 = .false.
+    real(kind=dp) :: t_now, t_next
+
     rank = pmc_mpi_rank()
     n_proc = pmc_mpi_size()
 
@@ -240,6 +244,8 @@ contains
        call print_part_progress(run_part_opt%i_repeat, time, &
             global_n_part, 0, 0, 0, 0, 0, t_wall_elapsed, t_wall_remain)
     end if
+
+if (option_1) then
 
     do i_time = i_time_start,n_time
 
@@ -386,6 +392,42 @@ contains
        end if
 
     end do
+else if (option_2) then
+
+    do i_time = i_time_start,n_time
+
+#ifdef PMC_USE_CAMP
+       call run_part_timestep(scenario, env_state, aero_data, aero_state, gas_data, &
+            gas_state, run_part_opt, camp_core, photolysis, &
+            real(i_time, kind=dp) * run_part_opt%del_t, t_start)
+#else
+       call run_part_timestep(scenario, env_state, aero_data, aero_state, gas_data, &
+            gas_state, run_part_opt, &
+            real(i_time, kind=dp) * run_part_opt%del_t, t_start, &
+            last_output_time, last_progress_time, i_output)
+#endif
+    end do
+else
+    n_time = int(run_part_opt%t_max/run_part_opt%t_progress) 
+    t_next = 0.0
+    do i_time = i_time_start,n_time
+       t_now = t_next  
+       t_next = t_now + 3600.0d0
+
+#ifdef PMC_USE_CAMP
+       call run_part_timeblock(scenario, env_state, aero_data, aero_state, &
+            gas_data, &
+            gas_state, run_part_opt, camp_core, photolysis, &
+            real(i_time, kind=dp) * run_part_opt%del_t, t_start)
+#else
+       call run_part_timeblock(scenario, env_state, aero_data, aero_state, &
+            gas_data, &
+            gas_state, run_part_opt, t_now, t_next, t_start, last_output_time, &
+            last_progress_time, i_output)
+#endif
+    end do
+
+end if
 
     if (run_part_opt%do_mosaic) then
        call mosaic_cleanup()
@@ -618,6 +660,420 @@ contains
     end if
 
   end subroutine spec_file_read_parallel_coag_type
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#ifdef PMC_USE_CAMP
+  subroutine run_part_timestep(scenario, env_state, aero_data, aero_state, gas_data, &
+       gas_state, run_part_opt, camp_core, photolysis)
+#else
+  subroutine run_part_timestep(scenario, env_state, aero_data, aero_state, gas_data, &
+       gas_state, run_part_opt, t_now, t_start, last_output_time, &
+       last_progress_time, i_output)
+#endif
+    !> Environment state.
+    type(scenario_t), intent(in) :: scenario
+    !> Environment state.
+    type(env_state_t), intent(inout) :: env_state
+    !> Aerosol data.
+    type(aero_data_t), intent(in) :: aero_data
+    !> Aerosol state.
+    type(aero_state_t), intent(inout) :: aero_state
+    !> Gas data.
+    type(gas_data_t), intent(in) :: gas_data
+    !> Gas state.
+    type(gas_state_t), intent(inout) :: gas_state
+    !> Monte Carlo options.
+    type(run_part_opt_t), intent(in) :: run_part_opt
+#ifdef PMC_USE_CAMP
+    !> CAMP chemistry core
+    type(camp_core_t), pointer, intent(inout), optional :: camp_core
+    !> Photolysis calculator
+    type(photolysis_t), pointer, intent(inout), optional :: photolysis
+
+    type(camp_state_t), pointer :: camp_state
+    type(camp_state_t), pointer :: camp_pre_aero_state, camp_post_aero_state
+#endif
+    real(kind=dp), intent(in) :: t_now, t_start
+    integer, intent(inout) :: i_output
+
+    real(kind=dp) :: time, pre_time, pre_del_t, prop_done
+    real(kind=dp) :: last_output_time, last_progress_time
+    integer :: rank, n_proc, pre_index, ncid
+    integer :: pre_i_repeat
+    integer :: n_samp, n_coag, n_emit, n_dil_in, n_dil_out, n_nuc
+    integer :: progress_n_samp, progress_n_coag
+    integer :: progress_n_emit, progress_n_dil_in, progress_n_dil_out
+    integer :: progress_n_nuc, n_part_before
+    integer :: global_n_part, global_n_samp, global_n_coag
+    integer :: global_n_emit, global_n_dil_in, global_n_dil_out
+    integer :: global_n_nuc
+    logical :: do_output, do_state, do_state_netcdf, do_progress, did_coag
+    real(kind=dp) :: t_wall_now, t_wall_elapsed, t_wall_remain
+    type(env_state_t) :: old_env_state
+    integer :: n_time, i_time, i_time_start, pre_i_time
+    integer :: i_state, i_state_netcdf
+#ifdef PMC_USE_CAMP
+    type(camp_env_state_t) :: camp_env_state
+#endif
+
+    time = t_now !real(i_time, kind=dp) * run_part_opt%del_t
+
+    old_env_state = env_state
+    call scenario_update_env_state(scenario, env_state, time + t_start)
+
+    if (run_part_opt%do_nucleation) then
+       n_part_before = aero_state_total_particles(aero_state)
+       call nucleate(run_part_opt%nucleate_type, &
+            run_part_opt%nucleate_source, env_state, gas_data, aero_data, &
+            aero_state, gas_state, run_part_opt%del_t, &
+            run_part_opt%allow_doubling, run_part_opt%allow_halving)
+       n_nuc = aero_state_total_particles(aero_state) &
+            - n_part_before
+       progress_n_nuc = progress_n_nuc + n_nuc
+    end if
+
+    if (run_part_opt%do_coagulation) then
+       if (run_part_opt%parallel_coag_type &
+            == PARALLEL_COAG_TYPE_LOCAL) then
+          call mc_coag(run_part_opt%coag_kernel_type, env_state, &
+               aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
+       elseif (run_part_opt%parallel_coag_type &
+            == PARALLEL_COAG_TYPE_DIST) then
+          call mc_coag_dist(run_part_opt%coag_kernel_type, env_state, &
+               aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
+       else
+          call die_msg(323011762, "unknown parallel coagulation type: " &
+               // trim(integer_to_string(run_part_opt%parallel_coag_type)))
+       end if
+       progress_n_samp = progress_n_samp + n_samp
+       progress_n_coag = progress_n_coag + n_coag
+    end if
+
+#ifdef PMC_USE_SUNDIALS
+    if (run_part_opt%do_condensation) then
+       call condense_particles(aero_state, aero_data, old_env_state, &
+            env_state, run_part_opt%del_t)
+    end if
+#endif
+
+    call scenario_update_gas_state(scenario, run_part_opt%del_t, &
+         env_state, old_env_state, gas_data, gas_state)
+    call scenario_update_aero_state(scenario, run_part_opt%del_t, &
+         env_state, old_env_state, aero_data, aero_state, n_emit, &
+         n_dil_in, n_dil_out, run_part_opt%allow_doubling, &
+         run_part_opt%allow_halving)
+    progress_n_emit = progress_n_emit + n_emit
+    progress_n_dil_in = progress_n_dil_in + n_dil_in
+    progress_n_dil_out = progress_n_dil_out + n_dil_out
+
+    if (run_part_opt%do_camp_chem) then
+#ifdef PMC_USE_CAMP
+       call pmc_camp_interface_solve(camp_core, camp_state, &
+            camp_pre_aero_state, camp_post_aero_state, env_state, &
+            aero_data, aero_state, gas_data, gas_state, photolysis, &
+            run_part_opt%del_t)
+#endif
+    end if
+
+    if (run_part_opt%do_mosaic) then
+       call mosaic_timestep(env_state, aero_data, aero_state, gas_data, &
+            gas_state, run_part_opt%do_optical)
+    end if
+
+    if (run_part_opt%mix_timescale > 0d0) then
+       call aero_state_mix(aero_state, run_part_opt%del_t, &
+            run_part_opt%mix_timescale, aero_data)
+    end if
+    if (run_part_opt%gas_average) then
+       call gas_state_mix(gas_state)
+    end if
+    if (run_part_opt%gas_average) then
+       call env_state_mix(env_state)
+    end if
+
+    call aero_state_rebalance(aero_state, aero_data, &
+         run_part_opt%allow_doubling, &
+         run_part_opt%allow_halving, initial_state_warning=.false.)
+
+
+    if (run_part_opt%t_output > 0d0) then
+       call check_event(time, run_part_opt%del_t, run_part_opt%t_output, &
+            last_output_time, do_output)
+       if (do_output) then
+          i_output = i_output + 1
+          call output_state(run_part_opt%output_prefix, &
+               run_part_opt%output_type, aero_data, aero_state, gas_data, &
+               gas_state, env_state, i_output, time, run_part_opt%del_t, &
+               run_part_opt%i_repeat, run_part_opt%record_removals, &
+               run_part_opt%do_optical, run_part_opt%uuid)
+          call aero_info_array_zero(aero_state%aero_info_array)
+       end if
+    end if
+
+    if (.not. run_part_opt%record_removals) then
+       ! If we are not recording removals then we can zero them as
+       ! often as possible to minimize the cost of maintaining
+       ! them.
+       call aero_info_array_zero(aero_state%aero_info_array)
+    end if
+
+    if (run_part_opt%t_progress > 0d0) then
+       call check_event(time, run_part_opt%del_t, &
+            run_part_opt%t_progress, last_progress_time, do_progress)
+       if (do_progress) then
+          global_n_part = aero_state_total_particles_all_procs(aero_state)
+          call pmc_mpi_reduce_sum_integer(progress_n_samp, global_n_samp)
+          call pmc_mpi_reduce_sum_integer(progress_n_coag, global_n_coag)
+          call pmc_mpi_reduce_sum_integer(progress_n_emit, global_n_emit)
+          call pmc_mpi_reduce_sum_integer(progress_n_dil_in, &
+               global_n_dil_in)
+          call pmc_mpi_reduce_sum_integer(progress_n_dil_out, &
+               global_n_dil_out)
+          call pmc_mpi_reduce_sum_integer(progress_n_nuc, global_n_nuc)
+          if (rank == 0) then
+             ! progress only printed from root process
+             call cpu_time(t_wall_now)
+             prop_done = (real(run_part_opt%i_repeat - 1, kind=dp) &
+                  + time / run_part_opt%t_max) &
+                  / real(run_part_opt%n_repeat, kind=dp)
+             t_wall_elapsed = t_wall_now - run_part_opt%t_wall_start
+             t_wall_remain = (1d0 - prop_done) / prop_done &
+                  * t_wall_elapsed
+             call print_part_progress(run_part_opt%i_repeat, time, &
+                  global_n_part, global_n_coag, global_n_emit, &
+                  global_n_dil_in, global_n_dil_out, global_n_nuc, &
+                  t_wall_elapsed, t_wall_remain)
+          end if
+          ! reset counters so they show information since last
+          ! progress display
+          progress_n_samp = 0
+          progress_n_coag = 0
+          progress_n_emit = 0
+          progress_n_dil_in = 0
+          progress_n_dil_out = 0
+          progress_n_nuc = 0
+       end if
+    end if
+
+  end subroutine run_part_timestep
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+#ifdef PMC_USE_CAMP
+  subroutine run_part_timeblock(scenario, env_state, aero_data, aero_state, gas_data, &
+       gas_state, run_part_opt, camp_core, photolysis)
+#else
+  subroutine run_part_timeblock(scenario, env_state, aero_data, aero_state, gas_data, &
+       gas_state, run_part_opt, t_now, t_next, t_start, last_output_time, &
+       last_progress_time, i_output)
+#endif
+    !> Environment state.
+    type(scenario_t), intent(in) :: scenario
+    !> Environment state.
+    type(env_state_t), intent(inout) :: env_state
+    !> Aerosol data.
+    type(aero_data_t), intent(in) :: aero_data
+    !> Aerosol state.
+    type(aero_state_t), intent(inout) :: aero_state
+    !> Gas data.
+    type(gas_data_t), intent(in) :: gas_data
+    !> Gas state.
+    type(gas_state_t), intent(inout) :: gas_state
+    !> Monte Carlo options.
+    type(run_part_opt_t), intent(in) :: run_part_opt
+#ifdef PMC_USE_CAMP
+    !> CAMP chemistry core
+    type(camp_core_t), pointer, intent(inout), optional :: camp_core
+    !> Photolysis calculator
+    type(photolysis_t), pointer, intent(inout), optional :: photolysis
+
+    type(camp_state_t), pointer :: camp_state
+    type(camp_state_t), pointer :: camp_pre_aero_state, camp_post_aero_state
+#endif
+    real(kind=dp), intent(in) :: t_now, t_start, t_next
+    real(kind=dp), intent(inout) :: last_output_time, &
+        last_progress_time
+    integer, intent(inout) :: i_output
+
+    real(kind=dp) :: time, pre_time, pre_del_t, prop_done
+    integer :: rank, n_proc, pre_index, ncid
+    integer :: pre_i_repeat
+    integer :: n_samp, n_coag, n_emit, n_dil_in, n_dil_out, n_nuc
+    integer :: progress_n_samp, progress_n_coag
+    integer :: progress_n_emit, progress_n_dil_in, progress_n_dil_out
+    integer :: progress_n_nuc, n_part_before
+    integer :: global_n_part, global_n_samp, global_n_coag
+    integer :: global_n_emit, global_n_dil_in, global_n_dil_out
+    integer :: global_n_nuc
+    logical :: do_output, do_state, do_state_netcdf, do_progress, did_coag
+    real(kind=dp) :: t_wall_now, t_wall_elapsed, t_wall_remain
+    type(env_state_t) :: old_env_state
+    integer :: n_time, i_time, i_time_start, pre_i_time
+    integer :: i_state, i_state_netcdf
+#ifdef PMC_USE_CAMP
+    type(camp_env_state_t) :: camp_env_state
+#endif
+
+    n_time = nint((t_next-t_now) / run_part_opt%del_t)
+    do i_time = 1,n_time
+       time = t_now + real(i_time, kind=dp) * run_part_opt%del_t
+
+#ifdef PMC_USE_CAMP
+       call run_part_timestep(scenario, env_state, aero_data, aero_state, &
+            gas_data, gas_state, run_part_opt, camp_core, photolysis, &
+            real(i_time, kind=dp) * run_part_opt%del_t, t_start)
+#else
+       call run_part_timestep(scenario, env_state, aero_data, aero_state, &
+            gas_data, gas_state, run_part_opt, &
+            time, t_start, last_output_time, last_progress_time, i_output)
+#endif
+    end do
+
+    return ! Avoid the rest
+
+    n_time = nint((t_next-t_now) / run_part_opt%del_t)
+    do i_time = 1,n_time
+
+       old_env_state = env_state
+       call scenario_update_env_state(scenario, env_state, time + t_start)
+
+       if (run_part_opt%do_nucleation) then
+          n_part_before = aero_state_total_particles(aero_state)
+          call nucleate(run_part_opt%nucleate_type, &
+               run_part_opt%nucleate_source, env_state, gas_data, aero_data, &
+               aero_state, gas_state, run_part_opt%del_t, &
+               run_part_opt%allow_doubling, run_part_opt%allow_halving)
+          n_nuc = aero_state_total_particles(aero_state) &
+               - n_part_before
+          progress_n_nuc = progress_n_nuc + n_nuc
+       end if
+
+       if (run_part_opt%do_coagulation) then
+          if (run_part_opt%parallel_coag_type &
+               == PARALLEL_COAG_TYPE_LOCAL) then
+             call mc_coag(run_part_opt%coag_kernel_type, env_state, &
+                  aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
+          elseif (run_part_opt%parallel_coag_type &
+               == PARALLEL_COAG_TYPE_DIST) then
+             call mc_coag_dist(run_part_opt%coag_kernel_type, env_state, &
+                  aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
+          else
+             call die_msg(323011762, "unknown parallel coagulation type: " &
+                  // trim(integer_to_string(run_part_opt%parallel_coag_type)))
+          end if
+          progress_n_samp = progress_n_samp + n_samp
+          progress_n_coag = progress_n_coag + n_coag
+       end if
+
+#ifdef PMC_USE_SUNDIALS
+       if (run_part_opt%do_condensation) then
+          call condense_particles(aero_state, aero_data, old_env_state, &
+               env_state, run_part_opt%del_t)
+       end if
+#endif
+
+       call scenario_update_gas_state(scenario, run_part_opt%del_t, &
+            env_state, old_env_state, gas_data, gas_state)
+       call scenario_update_aero_state(scenario, run_part_opt%del_t, &
+            env_state, old_env_state, aero_data, aero_state, n_emit, &
+            n_dil_in, n_dil_out, run_part_opt%allow_doubling, &
+            run_part_opt%allow_halving)
+       progress_n_emit = progress_n_emit + n_emit
+       progress_n_dil_in = progress_n_dil_in + n_dil_in
+       progress_n_dil_out = progress_n_dil_out + n_dil_out
+
+       if (run_part_opt%do_camp_chem) then
+#ifdef PMC_USE_CAMP
+          call pmc_camp_interface_solve(camp_core, camp_state, &
+               camp_pre_aero_state, camp_post_aero_state, env_state, &
+               aero_data, aero_state, gas_data, gas_state, photolysis, &
+               run_part_opt%del_t)
+#endif
+       end if
+
+       if (run_part_opt%do_mosaic) then
+          call mosaic_timestep(env_state, aero_data, aero_state, gas_data, &
+               gas_state, run_part_opt%do_optical)
+       end if
+
+       if (run_part_opt%mix_timescale > 0d0) then
+          call aero_state_mix(aero_state, run_part_opt%del_t, &
+               run_part_opt%mix_timescale, aero_data)
+       end if
+       if (run_part_opt%gas_average) then
+          call gas_state_mix(gas_state)
+       end if
+       if (run_part_opt%gas_average) then
+          call env_state_mix(env_state)
+       end if
+
+       call aero_state_rebalance(aero_state, aero_data, &
+            run_part_opt%allow_doubling, &
+            run_part_opt%allow_halving, initial_state_warning=.false.)
+
+
+       if (run_part_opt%t_output > 0d0) then
+          call check_event(time, run_part_opt%del_t, run_part_opt%t_output, &
+               last_output_time, do_output)
+          if (do_output) then
+             i_output = i_output + 1
+             call output_state(run_part_opt%output_prefix, &
+                  run_part_opt%output_type, aero_data, aero_state, gas_data, &
+                  gas_state, env_state, i_output, time, run_part_opt%del_t, &
+                  run_part_opt%i_repeat, run_part_opt%record_removals, &
+                  run_part_opt%do_optical, run_part_opt%uuid)
+             call aero_info_array_zero(aero_state%aero_info_array)
+          end if
+       end if
+
+       if (.not. run_part_opt%record_removals) then
+          ! If we are not recording removals then we can zero them as
+          ! often as possible to minimize the cost of maintaining
+          ! them.
+          call aero_info_array_zero(aero_state%aero_info_array)
+       end if
+
+       if (run_part_opt%t_progress > 0d0) then
+          call check_event(time, run_part_opt%del_t, &
+               run_part_opt%t_progress, last_progress_time, do_progress)
+          if (do_progress) then
+             global_n_part = aero_state_total_particles_all_procs(aero_state)
+             call pmc_mpi_reduce_sum_integer(progress_n_samp, global_n_samp)
+             call pmc_mpi_reduce_sum_integer(progress_n_coag, global_n_coag)
+             call pmc_mpi_reduce_sum_integer(progress_n_emit, global_n_emit)
+             call pmc_mpi_reduce_sum_integer(progress_n_dil_in, &
+                  global_n_dil_in)
+             call pmc_mpi_reduce_sum_integer(progress_n_dil_out, &
+                  global_n_dil_out)
+             call pmc_mpi_reduce_sum_integer(progress_n_nuc, global_n_nuc)
+             if (rank == 0) then
+                ! progress only printed from root process
+                call cpu_time(t_wall_now)
+                prop_done = (real(run_part_opt%i_repeat - 1, kind=dp) &
+                     + time / run_part_opt%t_max) &
+                     / real(run_part_opt%n_repeat, kind=dp)
+                t_wall_elapsed = t_wall_now - run_part_opt%t_wall_start
+                t_wall_remain = (1d0 - prop_done) / prop_done &
+                     * t_wall_elapsed
+                call print_part_progress(run_part_opt%i_repeat, time, &
+                     global_n_part, global_n_coag, global_n_emit, &
+                     global_n_dil_in, global_n_dil_out, global_n_nuc, &
+                     t_wall_elapsed, t_wall_remain)
+             end if
+             ! reset counters so they show information since last
+             ! progress display
+             progress_n_samp = 0
+             progress_n_coag = 0
+             progress_n_emit = 0
+             progress_n_dil_in = 0
+             progress_n_dil_out = 0
+             progress_n_nuc = 0
+          end if
+       end if
+!    end do
+
+  end subroutine run_part_timeblock
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/run_part.F90
+++ b/src/run_part.F90
@@ -237,11 +237,14 @@ contains
        call run_part_timeblock(scenario, env_state, aero_data, aero_state, &
             gas_data, gas_state, run_part_opt, camp_core, photolysis, &
             t_now, t_next, t_start, last_output_time, last_progress_time, &
-            i_output)
+            i_output, progress_n_samp, progress_n_coag, progress_n_emit, &
+            progress_n_dil_in, progress_n_dil_out, progress_n_nuc)
 #else
        call run_part_timeblock(scenario, env_state, aero_data, aero_state, &
             gas_data, gas_state, run_part_opt, t_now, t_next, t_start, & 
-            last_output_time, last_progress_time, i_output)
+            last_output_time, last_progress_time, i_output, progress_n_samp, &
+            progress_n_coag, progress_n_emit, progress_n_dil_in, &
+            progress_n_dil_out, progress_n_nuc)
 #endif
     end do
 
@@ -482,11 +485,15 @@ contains
 #ifdef PMC_USE_CAMP
   subroutine run_part_timestep(scenario, env_state, aero_data, aero_state, &
        gas_data, gas_state, run_part_opt, camp_core, photolysis, time, &
-       t_start, last_output_time, last_progress_time, i_output)
+       t_start, last_output_time, last_progress_time, i_output, &
+       progress_n_samp, progress_n_coag, progress_n_emit, progress_n_dil_in, &
+       progress_n_dil_out, progress_n_nuc)
 #else
   subroutine run_part_timestep(scenario, env_state, aero_data, aero_state, &
        gas_data, gas_state, run_part_opt, time, t_start, last_output_time, &
-       last_progress_time, i_output)
+       last_progress_time, i_output, progress_n_samp, progress_n_coag, &
+       progress_n_emit, progress_n_dil_in, progress_n_dil_out, &
+       progress_n_nuc)
 #endif
     !> Environment state.
     type(scenario_t), intent(in) :: scenario
@@ -518,12 +525,22 @@ contains
     real(kind=dp), intent(inout) :: last_progress_time
     !> Output timestep integer for output filename.
     integer, intent(inout) :: i_output
+    !> Total number of samples tested.
+    integer, intent(inout) :: progress_n_samp
+    !> Number of coagulation events.
+    integer, intent(inout) :: progress_n_coag
+    !> Number of particles added by emission.
+    integer, intent(inout) :: progress_n_emit
+    !> Number of particles added by dilution.
+    integer, intent(inout) :: progress_n_dil_in
+    !> Number of particles removed by dilution.
+    integer, intent(inout) :: progress_n_dil_out
+    !> Number of particles added by nucleation.
+    integer, intent(inout) :: progress_n_nuc
 
     real(kind=dp) :: prop_done
     integer :: n_samp, n_coag, n_emit, n_dil_in, n_dil_out, n_nuc
-    integer :: progress_n_samp, progress_n_coag
-    integer :: progress_n_emit, progress_n_dil_in, progress_n_dil_out
-    integer :: progress_n_nuc, n_part_before
+    integer :: n_part_before
     integer :: global_n_part, global_n_samp, global_n_coag
     integer :: global_n_emit, global_n_dil_in, global_n_dil_out
     integer :: global_n_nuc
@@ -535,13 +552,6 @@ contains
     type(camp_state_t), pointer :: camp_pre_aero_state, camp_post_aero_state
     type(camp_env_state_t) :: camp_env_state
 #endif
-
-    progress_n_samp = 0
-    progress_n_coag = 0
-    progress_n_emit = 0
-    progress_n_dil_in = 0
-    progress_n_dil_out = 0
-    progress_n_nuc = 0
 
 #ifdef PMC_USE_CAMP
     if (run_part_opt%do_camp_chem) then
@@ -697,11 +707,15 @@ contains
 #ifdef PMC_USE_CAMP
   subroutine run_part_timeblock(scenario, env_state, aero_data, aero_state, &
        gas_data, gas_state, run_part_opt, camp_core, photolysis, t_now, &
-       t_next, t_start, last_output_time, last_progress_time, i_output)
+       t_next, t_start, last_output_time, last_progress_time, i_output, &
+       progress_n_samp, progress_n_coag, progress_n_emit, progress_n_dil_in, &
+       progress_n_dil_out, progress_n_nuc)
 #else
   subroutine run_part_timeblock(scenario, env_state, aero_data, aero_state, &
        gas_data, gas_state, run_part_opt, t_now, t_next, t_start, &
-       last_output_time, last_progress_time, i_output)
+       last_output_time, last_progress_time, i_output, progress_n_samp, &
+       progress_n_coag, progress_n_emit, progress_n_dil_in, &
+       progress_n_dil_out, progress_n_nuc)
 #endif
     !> Environment state.
     type(scenario_t), intent(in) :: scenario
@@ -735,13 +749,20 @@ contains
     real(kind=dp), intent(inout) :: last_progress_time
     !> Output timestep integer for output filename.
     integer, intent(inout) :: i_output
+    !> Total number of samples tested.
+    integer, intent(inout) :: progress_n_samp
+    !> Number of coagulation events.
+    integer, intent(inout) :: progress_n_coag
+    !> Number of particles added by emission.
+    integer, intent(inout) :: progress_n_emit
+    !> Number of particles added by dilution.
+    integer, intent(inout) :: progress_n_dil_in
+    !> Number of particles removed by dilution.
+    integer, intent(inout) :: progress_n_dil_out
+    !> Number of particles added by nucleation.
+    integer, intent(inout) :: progress_n_nuc
 
     real(kind=dp) :: time
-    integer :: n_samp, n_coag, n_emit, n_dil_in, n_dil_out, n_nuc
-    integer :: progress_n_samp, progress_n_coag
-    integer :: progress_n_emit, progress_n_dil_in, progress_n_dil_out
-    integer :: progress_n_nuc, n_part_before
-    real(kind=dp) :: t_wall_now, t_wall_elapsed, t_wall_remain
     integer :: n_time, i_time, i_time_start
 
     n_time = nint((t_next-t_now) / run_part_opt%del_t)
@@ -752,11 +773,15 @@ contains
        call run_part_timestep(scenario, env_state, aero_data, aero_state, &
             gas_data, gas_state, run_part_opt, camp_core, photolysis, &
             real(i_time, kind=dp) * run_part_opt%del_t, t_start, &
-            last_output_time, last_progress_time, i_output)
+            last_output_time, last_progress_time, i_output, progress_n_samp, &
+            progress_n_coag, progress_n_emit, progress_n_dil_in, &
+            progress_n_dil_out, progress_n_nuc)
 #else
        call run_part_timestep(scenario, env_state, aero_data, aero_state, &
-            gas_data, gas_state, run_part_opt, &
-            time, t_start, last_output_time, last_progress_time, i_output)
+            gas_data, gas_state, run_part_opt, time, t_start, &
+            last_output_time, last_progress_time, i_output, progress_n_samp, &
+            progress_n_coag, progress_n_emit, progress_n_dil_in, &
+            progress_n_dil_out, progress_n_nuc)
 #endif
     end do
 

--- a/src/run_part.F90
+++ b/src/run_part.F90
@@ -768,14 +768,12 @@ contains
     n_time = nint((t_next-t_now) / run_part_opt%del_t)
     do i_time = 1,n_time
        time = t_now + real(i_time, kind=dp) * run_part_opt%del_t
-
 #ifdef PMC_USE_CAMP
        call run_part_timestep(scenario, env_state, aero_data, aero_state, &
-            gas_data, gas_state, run_part_opt, camp_core, photolysis, &
-            real(i_time, kind=dp) * run_part_opt%del_t, t_start, &
-            last_output_time, last_progress_time, i_output, progress_n_samp, &
-            progress_n_coag, progress_n_emit, progress_n_dil_in, &
-            progress_n_dil_out, progress_n_nuc)
+            gas_data, gas_state, run_part_opt, camp_core, photolysis, time, &
+            t_start, last_output_time, last_progress_time, i_output, &
+            progress_n_samp, progress_n_coag, progress_n_emit, &
+            progress_n_dil_in, progress_n_dil_out, progress_n_nuc)
 #else
        call run_part_timestep(scenario, env_state, aero_data, aero_state, &
             gas_data, gas_state, run_part_opt, time, t_start, &

--- a/src/run_part.F90
+++ b/src/run_part.F90
@@ -117,9 +117,10 @@ contains
   subroutine run_part(scenario, env_state, aero_data, aero_state, gas_data, &
        gas_state, run_part_opt, camp_core, photolysis)
 #else
-  subroutine run_part(scenario, env_state, aero_data, aero_state, gas_data, &
+   subroutine run_part(scenario, env_state, aero_data, aero_state, gas_data, &
        gas_state, run_part_opt)
 #endif
+
     !> Environment state.
     type(scenario_t), intent(in) :: scenario
     !> Environment state.
@@ -228,19 +229,15 @@ contains
 
     i_cur = 1
     i_next = n_time
-#ifdef PMC_USE_CAMP
+
     call run_part_timeblock(scenario, env_state, aero_data, aero_state, &
-         gas_data, gas_state, run_part_opt, camp_core, photolysis, &
+         gas_data, gas_state, run_part_opt, &
+#ifdef PMC_USE_CAMP
+         camp_core, photolysis, &
+#endif
          i_cur, i_next, t_start, last_output_time, last_progress_time, &
          i_output, progress_n_samp, progress_n_coag, progress_n_emit, &
          progress_n_dil_in, progress_n_dil_out, progress_n_nuc)
-#else
-    call run_part_timeblock(scenario, env_state, aero_data, aero_state, &
-         gas_data, gas_state, run_part_opt, i_cur, i_next, t_start, &
-         last_output_time, last_progress_time, i_output, progress_n_samp, &
-         progress_n_coag, progress_n_emit, progress_n_dil_in, &
-         progress_n_dil_out, progress_n_nuc)
-#endif
 
     if (run_part_opt%do_mosaic) then
        call mosaic_cleanup()
@@ -477,19 +474,15 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Do a one particle-resolved Monte Carlo simulation timestep.
-#ifdef PMC_USE_CAMP
   subroutine run_part_timestep(scenario, env_state, aero_data, aero_state, &
-       gas_data, gas_state, run_part_opt, camp_core, photolysis, i_time, &
-       t_start, last_output_time, last_progress_time, i_output, &
+       gas_data, gas_state, run_part_opt, &
+#ifdef PMC_USE_CAMP
+       camp_core, photolysis, &
+#endif
+       i_time, t_start, last_output_time, last_progress_time, i_output, &
        progress_n_samp, progress_n_coag, progress_n_emit, progress_n_dil_in, &
        progress_n_dil_out, progress_n_nuc)
-#else
-  subroutine run_part_timestep(scenario, env_state, aero_data, aero_state, &
-       gas_data, gas_state, run_part_opt, i_time, t_start, last_output_time, &
-       last_progress_time, i_output, progress_n_samp, progress_n_coag, &
-       progress_n_emit, progress_n_dil_in, progress_n_dil_out, &
-       progress_n_nuc)
-#endif
+
     !> Environment state.
     type(scenario_t), intent(in) :: scenario
     !> Environment state.
@@ -702,19 +695,15 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Do a number of time steps of particle-reoslved Monte Carlo simulation.
-#ifdef PMC_USE_CAMP
   subroutine run_part_timeblock(scenario, env_state, aero_data, aero_state, &
-       gas_data, gas_state, run_part_opt, camp_core, photolysis, i_cur, &
-       i_next, t_start, last_output_time, last_progress_time, i_output, &
+       gas_data, gas_state, run_part_opt, &
+#ifdef PMC_USE_CAMP
+       camp_core, photolysis, &
+#endif
+       i_cur, i_next, t_start, last_output_time, last_progress_time, i_output, &
        progress_n_samp, progress_n_coag, progress_n_emit, progress_n_dil_in, &
        progress_n_dil_out, progress_n_nuc)
-#else
-  subroutine run_part_timeblock(scenario, env_state, aero_data, aero_state, &
-       gas_data, gas_state, run_part_opt, i_cur, i_next, t_start, &
-       last_output_time, last_progress_time, i_output, progress_n_samp, &
-       progress_n_coag, progress_n_emit, progress_n_dil_in, &
-       progress_n_dil_out, progress_n_nuc)
-#endif
+
     !> Environment state.
     type(scenario_t), intent(in) :: scenario
     !> Environment state.
@@ -763,19 +752,14 @@ contains
     integer :: i_time
 
     do i_time = i_cur,i_next
-#ifdef PMC_USE_CAMP
        call run_part_timestep(scenario, env_state, aero_data, aero_state, &
-            gas_data, gas_state, run_part_opt, camp_core, photolysis, i_time, &
-            t_start, last_output_time, last_progress_time, i_output, &
+            gas_data, gas_state, run_part_opt, &
+#ifdef PMC_USE_CAMP
+            camp_core, photolysis, &
+#endif
+            i_time, t_start, last_output_time, last_progress_time, i_output, &
             progress_n_samp, progress_n_coag, progress_n_emit, &
             progress_n_dil_in, progress_n_dil_out, progress_n_nuc)
-#else
-       call run_part_timestep(scenario, env_state, aero_data, aero_state, &
-            gas_data, gas_state, run_part_opt, i_time, t_start, &
-            last_output_time, last_progress_time, i_output, progress_n_samp, &
-            progress_n_coag, progress_n_emit, progress_n_dil_in, &
-            progress_n_dil_out, progress_n_nuc)
-#endif
     end do
 
   end subroutine run_part_timeblock

--- a/src/run_part.F90
+++ b/src/run_part.F90
@@ -117,7 +117,7 @@ contains
   subroutine run_part(scenario, env_state, aero_data, aero_state, gas_data, &
        gas_state, run_part_opt, camp_core, photolysis)
 #else
-   subroutine run_part(scenario, env_state, aero_data, aero_state, gas_data, &
+  subroutine run_part(scenario, env_state, aero_data, aero_state, gas_data, &
        gas_state, run_part_opt)
 #endif
 

--- a/src/run_part.F90
+++ b/src/run_part.F90
@@ -418,8 +418,8 @@ else
 #ifdef PMC_USE_CAMP
        call run_part_timeblock(scenario, env_state, aero_data, aero_state, &
             gas_data, gas_state, run_part_opt, camp_core, photolysis, &
-            real(i_time, kind=dp) * run_part_opt%del_t, t_start, &
-             last_output_time, last_progress_time, i_output)
+            t_now, t_next, t_start, last_output_time, last_progress_time, &
+            i_output)
 #else
        call run_part_timeblock(scenario, env_state, aero_data, aero_state, &
             gas_data, gas_state, run_part_opt, t_now, t_next, t_start, & 

--- a/src/run_part.F90
+++ b/src/run_part.F90
@@ -665,11 +665,11 @@ end if
 
 #ifdef PMC_USE_CAMP
   subroutine run_part_timestep(scenario, env_state, aero_data, aero_state, &
-       gas_data, gas_state, run_part_opt, camp_core, photolysis, t_now, &
+       gas_data, gas_state, run_part_opt, camp_core, photolysis, time, &
        t_start, last_output_time, last_progress_time, i_output)
 #else
   subroutine run_part_timestep(scenario, env_state, aero_data, aero_state, &
-       gas_data, gas_state, run_part_opt, t_now, t_start, last_output_time, &
+       gas_data, gas_state, run_part_opt, time, t_start, last_output_time, &
        last_progress_time, i_output)
 #endif
     !> Environment state.
@@ -693,7 +693,7 @@ end if
     type(photolysis_t), pointer, intent(inout), optional :: photolysis
 #endif
     !> Current simulation time.
-    real(kind=dp), intent(in) :: t_now
+    real(kind=dp), intent(in) :: time
     ! Start time of simulation.
     real(kind=dp), intent(in) :: t_start
     !> Last time output was written (s).
@@ -703,7 +703,7 @@ end if
     !> Output timestep integer for output filename.
     integer, intent(inout) :: i_output
 
-    real(kind=dp) :: time, pre_time, pre_del_t, prop_done
+    real(kind=dp) :: prop_done
     integer :: n_samp, n_coag, n_emit, n_dil_in, n_dil_out, n_nuc
     integer :: progress_n_samp, progress_n_coag
     integer :: progress_n_emit, progress_n_dil_in, progress_n_dil_out
@@ -725,11 +725,8 @@ end if
     progress_n_emit = 0
     progress_n_dil_in = 0
     progress_n_dil_out = 0
-    progress_n_num = 0
+    progress_n_nuc = 0
 
-
-
-    time = t_now !real(i_time, kind=dp) * run_part_opt%del_t
     old_env_state = env_state
     call scenario_update_env_state(scenario, env_state, time + t_start)
 

--- a/src/run_part.F90
+++ b/src/run_part.F90
@@ -165,7 +165,7 @@ contains
 #endif
 
     logical, parameter :: option_1 = .false.
-    logical, parameter :: option_2 = .false.
+    logical, parameter :: option_2 = .true.
     real(kind=dp) :: t_now, t_next
 
     rank = pmc_mpi_rank()
@@ -366,7 +366,7 @@ if (option_1) then
              call pmc_mpi_reduce_sum_integer(progress_n_dil_out, &
                   global_n_dil_out)
              call pmc_mpi_reduce_sum_integer(progress_n_nuc, global_n_nuc)
-             if (rank == 0) then
+             if (pmc_mpi_rank() == 0) then
                 ! progress only printed from root process
                 call cpu_time(t_wall_now)
                 prop_done = (real(run_part_opt%i_repeat - 1, kind=dp) &
@@ -399,7 +399,8 @@ else if (option_2) then
 #ifdef PMC_USE_CAMP
        call run_part_timestep(scenario, env_state, aero_data, aero_state, gas_data, &
             gas_state, run_part_opt, camp_core, photolysis, &
-            real(i_time, kind=dp) * run_part_opt%del_t, t_start)
+            real(i_time, kind=dp) * run_part_opt%del_t, t_start, &
+            last_output_time, last_progress_time, i_output)
 #else
        call run_part_timestep(scenario, env_state, aero_data, aero_state, gas_data, &
             gas_state, run_part_opt, &
@@ -410,20 +411,19 @@ else if (option_2) then
 else
     n_time = int(run_part_opt%t_max/run_part_opt%t_progress) 
     t_next = 0.0
-    do i_time = i_time_start,n_time
-       t_now = t_next  
-       t_next = t_now + 3600.0d0
+    do i_time = 1,n_time
+       t_now = t_next
+       t_next = t_now + run_part_opt%t_progress
 
 #ifdef PMC_USE_CAMP
        call run_part_timeblock(scenario, env_state, aero_data, aero_state, &
-            gas_data, &
-            gas_state, run_part_opt, camp_core, photolysis, &
-            real(i_time, kind=dp) * run_part_opt%del_t, t_start)
+            gas_data, gas_state, run_part_opt, camp_core, photolysis, &
+            real(i_time, kind=dp) * run_part_opt%del_t, t_start, &
+             last_output_time, last_progress_time, i_output)
 #else
        call run_part_timeblock(scenario, env_state, aero_data, aero_state, &
-            gas_data, &
-            gas_state, run_part_opt, t_now, t_next, t_start, last_output_time, &
-            last_progress_time, i_output)
+            gas_data, gas_state, run_part_opt, t_now, t_next, t_start, & 
+            last_output_time, last_progress_time, i_output)
 #endif
     end do
 
@@ -717,8 +717,16 @@ end if
     type(camp_env_state_t) :: camp_env_state
 #endif
 
-    time = t_now !real(i_time, kind=dp) * run_part_opt%del_t
+    progress_n_samp = 0
+    progress_n_coag = 0
+    progress_n_emit = 0
+    progress_n_dil_in = 0
+    progress_n_dil_out = 0
+    progress_n_num = 0
 
+
+
+    time = t_now !real(i_time, kind=dp) * run_part_opt%del_t
     old_env_state = env_state
     call scenario_update_env_state(scenario, env_state, time + t_start)
 
@@ -831,7 +839,7 @@ end if
           call pmc_mpi_reduce_sum_integer(progress_n_dil_out, &
                global_n_dil_out)
           call pmc_mpi_reduce_sum_integer(progress_n_nuc, global_n_nuc)
-          if (rank == 0) then
+          if (pmc_mpi_rank() == 0) then
              ! progress only printed from root process
              call cpu_time(t_wall_now)
              prop_done = (real(run_part_opt%i_repeat - 1, kind=dp) &
@@ -922,156 +930,14 @@ end if
 #ifdef PMC_USE_CAMP
        call run_part_timestep(scenario, env_state, aero_data, aero_state, &
             gas_data, gas_state, run_part_opt, camp_core, photolysis, &
-            real(i_time, kind=dp) * run_part_opt%del_t, t_start)
+            real(i_time, kind=dp) * run_part_opt%del_t, t_start, &
+            last_output_time, last_progress_time, i_output)
 #else
        call run_part_timestep(scenario, env_state, aero_data, aero_state, &
             gas_data, gas_state, run_part_opt, &
             time, t_start, last_output_time, last_progress_time, i_output)
 #endif
     end do
-
-    return ! Avoid the rest
-
-    n_time = nint((t_next-t_now) / run_part_opt%del_t)
-    do i_time = 1,n_time
-
-       old_env_state = env_state
-       call scenario_update_env_state(scenario, env_state, time + t_start)
-
-       if (run_part_opt%do_nucleation) then
-          n_part_before = aero_state_total_particles(aero_state)
-          call nucleate(run_part_opt%nucleate_type, &
-               run_part_opt%nucleate_source, env_state, gas_data, aero_data, &
-               aero_state, gas_state, run_part_opt%del_t, &
-               run_part_opt%allow_doubling, run_part_opt%allow_halving)
-          n_nuc = aero_state_total_particles(aero_state) &
-               - n_part_before
-          progress_n_nuc = progress_n_nuc + n_nuc
-       end if
-
-       if (run_part_opt%do_coagulation) then
-          if (run_part_opt%parallel_coag_type &
-               == PARALLEL_COAG_TYPE_LOCAL) then
-             call mc_coag(run_part_opt%coag_kernel_type, env_state, &
-                  aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
-          elseif (run_part_opt%parallel_coag_type &
-               == PARALLEL_COAG_TYPE_DIST) then
-             call mc_coag_dist(run_part_opt%coag_kernel_type, env_state, &
-                  aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
-          else
-             call die_msg(323011762, "unknown parallel coagulation type: " &
-                  // trim(integer_to_string(run_part_opt%parallel_coag_type)))
-          end if
-          progress_n_samp = progress_n_samp + n_samp
-          progress_n_coag = progress_n_coag + n_coag
-       end if
-
-#ifdef PMC_USE_SUNDIALS
-       if (run_part_opt%do_condensation) then
-          call condense_particles(aero_state, aero_data, old_env_state, &
-               env_state, run_part_opt%del_t)
-       end if
-#endif
-
-       call scenario_update_gas_state(scenario, run_part_opt%del_t, &
-            env_state, old_env_state, gas_data, gas_state)
-       call scenario_update_aero_state(scenario, run_part_opt%del_t, &
-            env_state, old_env_state, aero_data, aero_state, n_emit, &
-            n_dil_in, n_dil_out, run_part_opt%allow_doubling, &
-            run_part_opt%allow_halving)
-       progress_n_emit = progress_n_emit + n_emit
-       progress_n_dil_in = progress_n_dil_in + n_dil_in
-       progress_n_dil_out = progress_n_dil_out + n_dil_out
-
-       if (run_part_opt%do_camp_chem) then
-#ifdef PMC_USE_CAMP
-          call pmc_camp_interface_solve(camp_core, camp_state, &
-               camp_pre_aero_state, camp_post_aero_state, env_state, &
-               aero_data, aero_state, gas_data, gas_state, photolysis, &
-               run_part_opt%del_t)
-#endif
-       end if
-
-       if (run_part_opt%do_mosaic) then
-          call mosaic_timestep(env_state, aero_data, aero_state, gas_data, &
-               gas_state, run_part_opt%do_optical)
-       end if
-
-       if (run_part_opt%mix_timescale > 0d0) then
-          call aero_state_mix(aero_state, run_part_opt%del_t, &
-               run_part_opt%mix_timescale, aero_data)
-       end if
-       if (run_part_opt%gas_average) then
-          call gas_state_mix(gas_state)
-       end if
-       if (run_part_opt%gas_average) then
-          call env_state_mix(env_state)
-       end if
-
-       call aero_state_rebalance(aero_state, aero_data, &
-            run_part_opt%allow_doubling, &
-            run_part_opt%allow_halving, initial_state_warning=.false.)
-
-
-       if (run_part_opt%t_output > 0d0) then
-          call check_event(time, run_part_opt%del_t, run_part_opt%t_output, &
-               last_output_time, do_output)
-          if (do_output) then
-             i_output = i_output + 1
-             call output_state(run_part_opt%output_prefix, &
-                  run_part_opt%output_type, aero_data, aero_state, gas_data, &
-                  gas_state, env_state, i_output, time, run_part_opt%del_t, &
-                  run_part_opt%i_repeat, run_part_opt%record_removals, &
-                  run_part_opt%do_optical, run_part_opt%uuid)
-             call aero_info_array_zero(aero_state%aero_info_array)
-          end if
-       end if
-
-       if (.not. run_part_opt%record_removals) then
-          ! If we are not recording removals then we can zero them as
-          ! often as possible to minimize the cost of maintaining
-          ! them.
-          call aero_info_array_zero(aero_state%aero_info_array)
-       end if
-
-       if (run_part_opt%t_progress > 0d0) then
-          call check_event(time, run_part_opt%del_t, &
-               run_part_opt%t_progress, last_progress_time, do_progress)
-          if (do_progress) then
-             global_n_part = aero_state_total_particles_all_procs(aero_state)
-             call pmc_mpi_reduce_sum_integer(progress_n_samp, global_n_samp)
-             call pmc_mpi_reduce_sum_integer(progress_n_coag, global_n_coag)
-             call pmc_mpi_reduce_sum_integer(progress_n_emit, global_n_emit)
-             call pmc_mpi_reduce_sum_integer(progress_n_dil_in, &
-                  global_n_dil_in)
-             call pmc_mpi_reduce_sum_integer(progress_n_dil_out, &
-                  global_n_dil_out)
-             call pmc_mpi_reduce_sum_integer(progress_n_nuc, global_n_nuc)
-             if (rank == 0) then
-                ! progress only printed from root process
-                call cpu_time(t_wall_now)
-                prop_done = (real(run_part_opt%i_repeat - 1, kind=dp) &
-                     + time / run_part_opt%t_max) &
-                     / real(run_part_opt%n_repeat, kind=dp)
-                t_wall_elapsed = t_wall_now - run_part_opt%t_wall_start
-                t_wall_remain = (1d0 - prop_done) / prop_done &
-                     * t_wall_elapsed
-                call print_part_progress(run_part_opt%i_repeat, time, &
-                     global_n_part, global_n_coag, global_n_emit, &
-                     global_n_dil_in, global_n_dil_out, global_n_nuc, &
-                     t_wall_elapsed, t_wall_remain)
-             end if
-             ! reset counters so they show information since last
-             ! progress display
-             progress_n_samp = 0
-             progress_n_coag = 0
-             progress_n_emit = 0
-             progress_n_dil_in = 0
-             progress_n_dil_out = 0
-             progress_n_nuc = 0
-          end if
-       end if
-!    end do
 
   end subroutine run_part_timeblock
 

--- a/src/run_part.F90
+++ b/src/run_part.F90
@@ -727,6 +727,16 @@ end if
     progress_n_dil_out = 0
     progress_n_nuc = 0
 
+#ifdef PMC_USE_CAMP
+    if (run_part_opt%do_camp_chem) then
+       camp_env_state%temp = env_state%temp
+       camp_env_state%pressure = env_state%pressure
+       camp_state =>  camp_core%new_state_one_cell(camp_env_state)
+       camp_pre_aero_state => camp_core%new_state_one_cell(camp_env_state)
+       camp_post_aero_state => camp_core%new_state_one_cell(camp_env_state)
+    end if
+#endif
+
     old_env_state = env_state
     call scenario_update_env_state(scenario, env_state, time + t_start)
 
@@ -917,11 +927,6 @@ end if
     integer :: progress_n_nuc, n_part_before
     real(kind=dp) :: t_wall_now, t_wall_elapsed, t_wall_remain
     integer :: n_time, i_time, i_time_start
-#ifdef PMC_USE_CAMP
-    type(camp_state_t), pointer :: camp_state
-    type(camp_state_t), pointer :: camp_pre_aero_state, camp_post_aero_state
-    type(camp_env_state_t) :: camp_env_state
-#endif
 
     n_time = nint((t_next-t_now) / run_part_opt%del_t)
     do i_time = 1,n_time

--- a/src/run_part.F90
+++ b/src/run_part.F90
@@ -139,9 +139,6 @@ contains
     type(camp_core_t), pointer, intent(inout), optional :: camp_core
     !> Photolysis calculator
     type(photolysis_t), pointer, intent(inout), optional :: photolysis
-
-    type(camp_state_t), pointer :: camp_state
-    type(camp_state_t), pointer :: camp_pre_aero_state, camp_post_aero_state
 #endif
 
     real(kind=dp) :: time, pre_time, pre_del_t, prop_done
@@ -160,12 +157,6 @@ contains
     type(env_state_t) :: old_env_state
     integer :: n_time, i_time, i_time_start, pre_i_time
     integer :: i_state, i_state_netcdf, i_output
-#ifdef PMC_USE_CAMP
-    type(camp_env_state_t) :: camp_env_state
-#endif
-
-    logical, parameter :: option_1 = .false.
-    logical, parameter :: option_2 = .true.
     real(kind=dp) :: t_now, t_next
 
     rank = pmc_mpi_rank()
@@ -189,15 +180,6 @@ contains
          "del_t", run_part_opt%del_t)
     call check_time_multiple("t_progress", run_part_opt%t_progress, &
          "del_t", run_part_opt%del_t)
-#ifdef PMC_USE_CAMP
-    if (run_part_opt%do_camp_chem) then
-       camp_env_state%temp = env_state%temp
-       camp_env_state%pressure = env_state%pressure
-       camp_state =>  camp_core%new_state_one_cell(camp_env_state)
-       camp_pre_aero_state => camp_core%new_state_one_cell(camp_env_state)
-       camp_post_aero_state => camp_core%new_state_one_cell(camp_env_state)
-    end if
-#endif
 
     if (run_part_opt%do_mosaic) then
        call mosaic_init(env_state, aero_data, run_part_opt%del_t, &
@@ -245,170 +227,6 @@ contains
             global_n_part, 0, 0, 0, 0, 0, t_wall_elapsed, t_wall_remain)
     end if
 
-if (option_1) then
-
-    do i_time = i_time_start,n_time
-
-       time = real(i_time, kind=dp) * run_part_opt%del_t
-
-       old_env_state = env_state
-       call scenario_update_env_state(scenario, env_state, time + t_start)
-
-       if (run_part_opt%do_nucleation) then
-          n_part_before = aero_state_total_particles(aero_state)
-          call nucleate(run_part_opt%nucleate_type, &
-               run_part_opt%nucleate_source, env_state, gas_data, aero_data, &
-               aero_state, gas_state, run_part_opt%del_t, &
-               run_part_opt%allow_doubling, run_part_opt%allow_halving)
-          n_nuc = aero_state_total_particles(aero_state) &
-               - n_part_before
-          progress_n_nuc = progress_n_nuc + n_nuc
-       end if
-
-       if (run_part_opt%do_coagulation) then
-          if (run_part_opt%parallel_coag_type &
-               == PARALLEL_COAG_TYPE_LOCAL) then
-             call mc_coag(run_part_opt%coag_kernel_type, env_state, &
-                  aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
-          elseif (run_part_opt%parallel_coag_type &
-               == PARALLEL_COAG_TYPE_DIST) then
-             call mc_coag_dist(run_part_opt%coag_kernel_type, env_state, &
-                  aero_data, aero_state, run_part_opt%del_t, n_samp, n_coag)
-          else
-             call die_msg(323011762, "unknown parallel coagulation type: " &
-                  // trim(integer_to_string(run_part_opt%parallel_coag_type)))
-          end if
-          progress_n_samp = progress_n_samp + n_samp
-          progress_n_coag = progress_n_coag + n_coag
-       end if
-
-#ifdef PMC_USE_SUNDIALS
-       if (run_part_opt%do_condensation) then
-          call condense_particles(aero_state, aero_data, old_env_state, &
-               env_state, run_part_opt%del_t)
-       end if
-#endif
-
-       call scenario_update_gas_state(scenario, run_part_opt%del_t, &
-            env_state, old_env_state, gas_data, gas_state)
-       call scenario_update_aero_state(scenario, run_part_opt%del_t, &
-            env_state, old_env_state, aero_data, aero_state, n_emit, &
-            n_dil_in, n_dil_out, run_part_opt%allow_doubling, &
-            run_part_opt%allow_halving)
-       progress_n_emit = progress_n_emit + n_emit
-       progress_n_dil_in = progress_n_dil_in + n_dil_in
-       progress_n_dil_out = progress_n_dil_out + n_dil_out
-
-       if (run_part_opt%do_camp_chem) then
-#ifdef PMC_USE_CAMP
-          call pmc_camp_interface_solve(camp_core, camp_state, &
-               camp_pre_aero_state, camp_post_aero_state, env_state, &
-               aero_data, aero_state, gas_data, gas_state, photolysis, &
-               run_part_opt%del_t)
-#endif
-       end if
-
-       if (run_part_opt%do_mosaic) then
-          call mosaic_timestep(env_state, aero_data, aero_state, gas_data, &
-               gas_state, run_part_opt%do_optical)
-       end if
-
-       if (run_part_opt%mix_timescale > 0d0) then
-          call aero_state_mix(aero_state, run_part_opt%del_t, &
-               run_part_opt%mix_timescale, aero_data)
-       end if
-       if (run_part_opt%gas_average) then
-          call gas_state_mix(gas_state)
-       end if
-       if (run_part_opt%gas_average) then
-          call env_state_mix(env_state)
-       end if
-
-       call aero_state_rebalance(aero_state, aero_data, &
-            run_part_opt%allow_doubling, &
-            run_part_opt%allow_halving, initial_state_warning=.false.)
-
-       ! DEBUG: enable to check consistency
-       ! call aero_state_check(aero_state, aero_data)
-       ! DEBUG: end
-
-       if (run_part_opt%t_output > 0d0) then
-          call check_event(time, run_part_opt%del_t, run_part_opt%t_output, &
-               last_output_time, do_output)
-          if (do_output) then
-             i_output = i_output + 1
-             call output_state(run_part_opt%output_prefix, &
-                  run_part_opt%output_type, aero_data, aero_state, gas_data, &
-                  gas_state, env_state, i_output, time, run_part_opt%del_t, &
-                  run_part_opt%i_repeat, run_part_opt%record_removals, &
-                  run_part_opt%do_optical, run_part_opt%uuid)
-             call aero_info_array_zero(aero_state%aero_info_array)
-          end if
-       end if
-
-       if (.not. run_part_opt%record_removals) then
-          ! If we are not recording removals then we can zero them as
-          ! often as possible to minimize the cost of maintaining
-          ! them.
-          call aero_info_array_zero(aero_state%aero_info_array)
-       end if
-
-       if (run_part_opt%t_progress > 0d0) then
-          call check_event(time, run_part_opt%del_t, &
-               run_part_opt%t_progress, last_progress_time, do_progress)
-          if (do_progress) then
-             global_n_part = aero_state_total_particles_all_procs(aero_state)
-             call pmc_mpi_reduce_sum_integer(progress_n_samp, global_n_samp)
-             call pmc_mpi_reduce_sum_integer(progress_n_coag, global_n_coag)
-             call pmc_mpi_reduce_sum_integer(progress_n_emit, global_n_emit)
-             call pmc_mpi_reduce_sum_integer(progress_n_dil_in, &
-                  global_n_dil_in)
-             call pmc_mpi_reduce_sum_integer(progress_n_dil_out, &
-                  global_n_dil_out)
-             call pmc_mpi_reduce_sum_integer(progress_n_nuc, global_n_nuc)
-             if (pmc_mpi_rank() == 0) then
-                ! progress only printed from root process
-                call cpu_time(t_wall_now)
-                prop_done = (real(run_part_opt%i_repeat - 1, kind=dp) &
-                     + time / run_part_opt%t_max) &
-                     / real(run_part_opt%n_repeat, kind=dp)
-                t_wall_elapsed = t_wall_now - run_part_opt%t_wall_start
-                t_wall_remain = (1d0 - prop_done) / prop_done &
-                     * t_wall_elapsed
-                call print_part_progress(run_part_opt%i_repeat, time, &
-                     global_n_part, global_n_coag, global_n_emit, &
-                     global_n_dil_in, global_n_dil_out, global_n_nuc, &
-                     t_wall_elapsed, t_wall_remain)
-             end if
-             ! reset counters so they show information since last
-             ! progress display
-             progress_n_samp = 0
-             progress_n_coag = 0
-             progress_n_emit = 0
-             progress_n_dil_in = 0
-             progress_n_dil_out = 0
-             progress_n_nuc = 0
-          end if
-       end if
-
-    end do
-else if (option_2) then
-
-    do i_time = i_time_start,n_time
-
-#ifdef PMC_USE_CAMP
-       call run_part_timestep(scenario, env_state, aero_data, aero_state, &
-            gas_data, gas_state, run_part_opt, camp_core, photolysis, &
-            real(i_time, kind=dp) * run_part_opt%del_t, t_start, &
-            last_output_time, last_progress_time, i_output)
-#else
-       call run_part_timestep(scenario, env_state, aero_data, aero_state, &
-            gas_data, gas_state, run_part_opt, &
-            real(i_time, kind=dp) * run_part_opt%del_t, t_start, &
-            last_output_time, last_progress_time, i_output)
-#endif
-    end do
-else
     n_time = int(run_part_opt%t_max/run_part_opt%t_progress) 
     t_next = 0.0
     do i_time = 1,n_time
@@ -426,8 +244,6 @@ else
             last_output_time, last_progress_time, i_output)
 #endif
     end do
-
-end if
 
     if (run_part_opt%do_mosaic) then
        call mosaic_cleanup()


### PR DESCRIPTION
`run_part` both controls the timestepping and calls all the functions individually to progress an entire simulation (from time $t=0$ to $t=t_{\rm max}$. Instead it would be good to be able to run chunks of time, implemented with `run_part_timeblock` which will simulate from time $t$ to $t + t_{\rm progress}$ (or other specified interval), and a single timestep, implemented with `run_part_timestep` which runs from time $t$ to $t+\Delta t$.