### PR TITLE
add i_water to netcdf output and input

### DIFF
--- a/src/aero_data.F90
+++ b/src/aero_data.F90
@@ -760,6 +760,9 @@ contains
     call pmc_nc_write_real_1d(ncid, aero_data%kappa, &
          "aero_kappa", (/ dimid_aero_species /), unit="1", &
          long_name="hygroscopicity parameters (kappas) of aerosol species")
+    call pmc_nc_write_integer(ncid, aero_data%i_water, &
+         "aero_i_water", long_name="Index of aerosol water or " &
+         // "0 if water does not exist.")
     call fractal_output_netcdf(aero_data%fractal, ncid)
 
   end subroutine aero_data_output_netcdf
@@ -840,7 +843,7 @@ contains
     end do
     call assert(377166446, aero_source_names == "")
 
-    call aero_data_set_water_index(aero_data)
+    call pmc_nc_read_integer(ncid, aero_data%i_water, "aero_i_water")
 
     call fractal_input_netcdf(aero_data%fractal, ncid)
 


### PR DESCRIPTION
For simulations being post-processed that were run with CAMP, the index of aerosol water isn't successfully found. This breaks some aspects of the post-processing pipeline (such as drying a particle population or computing critical relative humidities) and (most likely) the cloud parcel model. The issue is that `aero_data_input_netcdf` reads in all aerosol species names and information but `aero_data_set_water_index()` won't find water with its current requirements of the string needing an exact match to "H2O" where water in CAMP usually is referred to as something like `aqeuous.H2O_aq`. PartMC with CAMP enabled relies on the water species having a special entry in the json files of "PartMC name", which then tags the value of `aero_data%i_water`.

Straight forward solution is to output the value of `aero_data%i_water` and then also read it in instead searching the names array list.