### PR TITLE
Add write format specifier in extract_aero_particle to be consistent with other extract_aero programs to avoid problems with ifx

### DIFF
--- a/src/extract_aero_particles.F90
+++ b/src/extract_aero_particles.F90
@@ -97,7 +97,7 @@ program extract_aero_particles
              aero_particle_species_mass(aero_state%apa%particle(i_part), &
              i_spec, aero_data)
      end do
-     write(out_unit, *) ''
+     write(out_unit, '(a)') ''
   end do
   call close_file(out_unit)
 


### PR DESCRIPTION
When compiling PartMC on the newer version of Keeling and Stampede3, when using Intel oneAPI compilers (ifx), the current write statement appears to introduce a new empty line rather than just ending the line like it does with gfortran. This breaks extract_aero_particle needed for some averaging tests as it introduces an empty line for every single particle in addition to a line with the actual values. This results in `numeric_diff` to fail due to long lines (`PartMC-516120334`).