### PR TITLE
Fix --out vs --output mismatch in extract program help text

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,8 @@
+codecov:
+  notify:
+    after_n_builds: 4
+    wait_for_ci: true
+
 coverage:
   status:
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,3 @@
-codecov:
-  notify:
-    after_n_builds: 4
-    wait_for_ci: true
-
 coverage:
   status:
     project:

--- a/src/extract_aero_particles.F90
+++ b/src/extract_aero_particles.F90
@@ -117,7 +117,7 @@ contains
     write(*,'(a)') ''
     write(*,'(a)') 'options are:'
     write(*,'(a)') '  -h, --help        Print this help message.'
-    write(*,'(a)') '  -o, --out <file>  Output filename.'
+    write(*,'(a)') '  -o, --output <file>  Output filename.'
     write(*,'(a)') ''
     write(*,'(a)') 'Examples:'
     write(*,'(a)') '  extract_aero_particles data_0001_00000001.nc'

--- a/src/extract_aero_size.F90
+++ b/src/extract_aero_size.F90
@@ -183,7 +183,7 @@ contains
     write(*,'(a)') '  -N, --dmin <D>    Minimum diameter (m).'
     write(*,'(a)') '  -X, --dmax <D>    Maximum diameter (m).'
     write(*,'(a)') '  -b, --nbin <N>    Number of size bins.'
-    write(*,'(a)') '  -o, --out <file>  Output filename.'
+    write(*,'(a)') '  -o, --output <file>  Output filename.'
     write(*,'(a)') ''
     write(*,'(a)') 'Examples:'
     write(*,'(a)') '  extract_aero_size --num data_0001'

--- a/src/extract_aero_time.F90
+++ b/src/extract_aero_time.F90
@@ -141,7 +141,7 @@ contains
     write(*,'(a)') ''
     write(*,'(a)') 'options are:'
     write(*,'(a)') '  -h, --help        Print this help message.'
-    write(*,'(a)') '  -o, --out <file>  Output filename.'
+    write(*,'(a)') '  -o, --output <file>  Output filename.'
     write(*,'(a)') ''
     write(*,'(a)') 'Examples:'
     write(*,'(a)') '  extract_aero_time data_0001'

--- a/src/extract_env.F90
+++ b/src/extract_env.F90
@@ -129,7 +129,7 @@ contains
     write(*,'(a)') ''
     write(*,'(a)') 'options are:'
     write(*,'(a)') '  -h, --help        Print this help message.'
-    write(*,'(a)') '  -o, --out <file>  Output filename.'
+    write(*,'(a)') '  -o, --output <file>  Output filename.'
     write(*,'(a)') ''
     write(*,'(a)') 'Examples:'
     write(*,'(a)') '  extract_env data_0001'

--- a/src/extract_gas.F90
+++ b/src/extract_gas.F90
@@ -120,7 +120,7 @@ contains
     write(*,'(a)') ''
     write(*,'(a)') 'options are:'
     write(*,'(a)') '  -h, --help        Print this help message.'
-    write(*,'(a)') '  -o, --out <file>  Output filename.'
+    write(*,'(a)') '  -o, --output <file>  Output filename.'
     write(*,'(a)') ''
     write(*,'(a)') 'Examples:'
     write(*,'(a)') '  extract_gas data_0001'

--- a/src/extract_sectional_aero_size.F90
+++ b/src/extract_sectional_aero_size.F90
@@ -164,7 +164,7 @@ contains
     write(*,'(a)') '  -h, --help        Print this help message.'
     write(*,'(a)') '  -n, --num         Output number distribution.'
     write(*,'(a)') '  -m, --mass        Output mass distribution.'
-    write(*,'(a)') '  -o, --out <file>  Output filename.'
+    write(*,'(a)') '  -o, --output <file>  Output filename.'
     write(*,'(a)') ''
     write(*,'(a)') 'Examples:'
     write(*,'(a)') '  extract_sectional_aero_size --num data_0001'

--- a/src/extract_sectional_aero_time.F90
+++ b/src/extract_sectional_aero_time.F90
@@ -135,7 +135,7 @@ contains
     write(*,'(a)') ''
     write(*,'(a)') 'options are:'
     write(*,'(a)') '  -h, --help        Print this help message.'
-    write(*,'(a)') '  -o, --out <file>  Output filename.'
+    write(*,'(a)') '  -o, --output <file>  Output filename.'
     write(*,'(a)') ''
     write(*,'(a)') 'Examples:'
     write(*,'(a)') '  extract_sectional_aero_time data_0001'


### PR DESCRIPTION
All seven `extract_*` programs registered the long option as `--output` but advertised `--out` in their help, causing `--out` to fail with "unknown option".