### PR TITLE
Update CI workflows and add codecov.yml to avoid flaky dips in coverage

### DIFF
--- a/.github/actions/codecov/action.yml
+++ b/.github/actions/codecov/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
 
     - name: Upload coverage report to codecov.io
-      uses: codecov/codecov-action@v5.5.0
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ inputs.codecov_token }}
         fail_ci_if_error: true

--- a/.github/workflows/camp.yml
+++ b/.github/workflows/camp.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v6
     - name: Build the testing docker image
       run: docker build -f Dockerfile.camp -t partmc-test .
     - name: Run the tests in the docker container

--- a/.github/workflows/cloud_parcel.yml
+++ b/.github/workflows/cloud_parcel.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v6
     - name: Build the testing docker image
       run: docker build -f Dockerfile.cloud_parcel -t partmc-test .
     - name: Run the tests in the docker container

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Build the testing docker image
       run: docker build -t partmc-doc -f Dockerfile.doc .
     - name: Run container to generate docs

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2 # https://github.com/marketplace/actions/checkout
+        uses: actions/checkout@v6 # https://github.com/marketplace/actions/checkout
         with:
           fetch-depth: 0
       - name: Set up QEMU

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v6
     - name: Build the testing docker image
       run: docker build -t partmc-test .
     - name: Run the tests in the docker container

--- a/.github/workflows/mpi.yml
+++ b/.github/workflows/mpi.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v6
     - name: Build the testing docker image
       run: docker build -f Dockerfile.mpi -t partmc-test . 
     - name: Run the tests in the docker container

--- a/.github/workflows/tchem.yml.temporarily_off
+++ b/.github/workflows/tchem.yml.temporarily_off
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v6
     - name: Build the testing docker image
       run: docker build -f Dockerfile.tchem -t partmc-test .
     - name: Run the tests in the docker container

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
- Manually updated/unified checkout in workflows to accommodate GitHub Node.js soon to be requirements. GitHub has transitioned its Actions runners to execute JavaScript actions using Node.js 24 by default as of June 2, 2026.
- Bump codecov version as recent PRs (#211, #223, etc.) are failing to upload codecov data. Currently not pinned to a specific version (v6 in general) as we typically have not worried about pinning previously (even though codecov was specifically pinned to 5.5.0)
- Add codecov.yml that sets a 1% threshold on both project and patch coverage so small coverage dips don't fail CI. Additionally, there is now something in place if we want more customization.